### PR TITLE
Upgrade XIR version to 0.2.0-dev

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,12 @@
+## Release 0.2.0 (development release)
+
+### Contributors
+
+This release contains contributions from (in alphabetical order):
+
+[Mikhail Andrenkov](https://github.com/Mandrenkov).
+
+
 ## Release 0.1.0 (current release)
 
 ### New features since last release

--- a/xir/_version.py
+++ b/xir/_version.py
@@ -1,3 +1,3 @@
 """The current version number. Uses semantic versioning (https://semver.org)"""
 
-__version__ = "0.1.0"
+__version__ = "0.2.0-dev"


### PR DESCRIPTION
**Context:**
Version 0.1.0 of the XIR has been released.

**Description of the Change:**
- The XIR version has been bumped to `0.2.0-dev`.

**Benefits:**
- The XIR version is correct.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None