### PR TITLE
Fix wires in definitions

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -40,7 +40,7 @@ gate h(x)[a, b, c]:
     // rx(pi / sin(3 * 4 / 2 - 2)) | [b, c];
 end;
 
-obs o(a):
+obs o(a)[0, 1]:
     sin(a), X[0] @ Z[1];
     -1.6, Y[0];
     2.45, Y[0] @ X[1];

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -172,3 +172,101 @@ class TestParser:
         """
         with pytest.raises(UnexpectedToken, match=r"Unexpected token"):
             parse_script(f"use {include};")
+
+    @pytest.mark.parametrize(
+        "stmt, expected_wires",
+        [
+            (
+                "gate MultiRot(x, y, z): RX(x) | [0]; RY(y) | [0]; RZ(z) | [0]; end;",
+                (0,),
+            ),
+            (
+                "gate MultiRot(x, y, z): RX(x) | [0]; RY(y) | [1]; RZ(z) | [2]; end;",
+                (0, 1, 2),
+            ),
+            (
+                "gate MultiRot(x, y, z): RX(x) | [0]; RY(y) | [1]; RZ(z) | [1]; end;",
+                (0, 1),
+            ),
+            (
+                "gate MultiRot(x, y, z): RX(x) | [0]; RY(y) | [0]; RZ(z) | [3]; end;",
+                (0, 1, 2, 3),
+            ),
+            (
+                "gate MultiRot(x, y, z): RX(x) | [4]; RY(y) | [4]; RZ(z) | [4]; end;",
+                (0, 1, 2, 3, 4),
+            ),
+            (
+                "gate MultiRot(x, y, z)[4]: RX(x) | [4]; RY(y) | [4]; RZ(z) | [4]; end;",
+                (4,),
+            ),
+            (
+                "gate MultiRot(x, y, z)[b, a]: RX(x) | [a]; RY(y) | [b]; RZ(z) | [a]; end;",
+                ("b", "a"),
+            ),
+            (
+                "gate MultiRot(x, y, z)[0, 1, 2, 3]: RX(x) | [0]; RY(y) | [2]; RZ(z) | [0]; end;",
+                (0, 1, 2, 3),
+            ),
+        ],
+    )
+    def test_gate_definition_wires(self, stmt, expected_wires):
+        """Tests that wires are correctly declared when defining a gate."""
+        script = f"gate RX(x)[0];gate RY(x)[0];gate RZ(x)[0]; {stmt}"
+        program = parse_script(script)
+
+        assert program.declarations["gate"][0].name == "RX"
+        assert program.declarations["gate"][1].name == "RY"
+        assert program.declarations["gate"][2].name == "RZ"
+
+        assert program.declarations["gate"][3].name == "MultiRot"
+        assert program.declarations["gate"][3].wires == expected_wires
+
+    @pytest.mark.parametrize(
+        "stmt, expected_wires",
+        [
+            (
+                "obs Orange(x, y, z): 1.2, X[0]; end;",
+                (0,),
+            ),
+            (
+                "obs Orange(x, y, z): 4.1, X[0] @ Y[1]; 1, Z[2]; end;",
+                (0, 1, 2),
+            ),
+            (
+                "obs Orange(x, y, z): 1, X[0] @ Y[1]; 1, Z[1]; end;",
+                (0, 1),
+            ),
+            (
+                "obs Orange(x, y, z): 1, X[3] @ Y[1]; 1.4, Z[0] @ Y[2]; end;",
+                (0, 1, 2, 3),
+            ),
+            (
+                "obs Orange(x, y, z): 1, X[4]; 1, Z[4]; end;",
+                (0, 1, 2, 3, 4),
+            ),
+            (
+                "obs Orange(x, y, z)[4]: 2.2, X[4]; 1, Z[4]; end;",
+                (4,),
+            ),
+            (
+                "obs Orange(x, y, z)[b, a]: 1, X[a] @ Y[b]; 1, Z[b]; end;",
+                ("b", "a"),
+            ),
+            (
+                "obs Orange(x, y, z)[0, 1, 2, 3]: 1, X[0] @ Y[2]; 0.42, Z[0]; end;",
+                (0, 1, 2, 3),
+            ),
+        ],
+    )
+    def test_observable_definition_wires(self, stmt, expected_wires):
+        """Tests that wires are correctly declared when defining an observable."""
+        script = f"obs X[0];obs Y[0];obs Z[0]; {stmt}"
+        program = parse_script(script)
+
+        assert program.declarations["obs"][0].name == "X"
+        assert program.declarations["obs"][1].name == "Y"
+        assert program.declarations["obs"][2].name == "Z"
+
+        assert program.declarations["obs"][3].name == "Orange"
+        assert program.declarations["obs"][3].wires == expected_wires

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -70,6 +70,30 @@ class TestValidatorIntegration:
                     "Declaration 'gate cnot[0, 0]' has duplicate wires labels.",
                 ],
             ),
+        ],
+    )
+    def test_message_reset(self, decl, matches):
+        """Tests that validator messages are reset between different runs."""
+
+        match = self._create_full_match(matches)
+        with pytest.raises(xir.validator.ValidationError, match=match):
+            program = xir.parse_script(decl)
+            xir.Validator(program).run()
+
+        # run it again to make sure the issue messages don't "pile up"
+        with pytest.raises(xir.validator.ValidationError, match=match):
+            program = xir.parse_script(decl)
+            xir.Validator(program).run()
+
+    @pytest.mark.parametrize(
+        "decl, matches",
+        [
+            (
+                "gate cnot[0, 0];",
+                [
+                    "Declaration 'gate cnot[0, 0]' has duplicate wires labels.",
+                ],
+            ),
             (
                 "gate Sgate(a, a)[0];",
                 [
@@ -89,8 +113,8 @@ class TestValidatorIntegration:
 
         match = self._create_full_match(matches)
         with pytest.raises(xir.validator.ValidationError, match=match):
-            irprog = xir.parse_script(decl)
-            xir.Validator(irprog).run()
+            program = xir.parse_script(decl)
+            xir.Validator(program).run()
 
     @pytest.mark.parametrize(
         "stmt, matches",
@@ -175,8 +199,8 @@ class TestValidatorIntegration:
 
         match = self._create_full_match(matches)
         with pytest.raises(xir.validator.ValidationError, match=match):
-            irprog = xir.parse_script(script)
-            xir.Validator(irprog).run()
+            program = xir.parse_script(script)
+            xir.Validator(program).run()
 
     def test_check_recursive_defs(self):
         """Test that recursively defined definitions raise the correct exceptions."""
@@ -184,11 +208,11 @@ class TestValidatorIntegration:
         script = inspect.cleandoc(
             """
             gate MooGate:
-                MyGate | [0, 2];
+                MyGate | [0, 1];
             end;
 
             gate MyGate:
-                MooGate | [0, 2];
+                MooGate | [0, 1];
             end;
             """
         )
@@ -200,8 +224,8 @@ class TestValidatorIntegration:
 
         match = self._create_full_match(matches)
         with pytest.raises(xir.validator.ValidationError, match=match):
-            irprog = xir.parse_script(script)
-            xir.Validator(irprog).run()
+            program = xir.parse_script(script)
+            xir.Validator(program).run()
 
     @pytest.mark.parametrize(
         "stmt, matches",
@@ -236,8 +260,8 @@ class TestValidatorIntegration:
                 "gate MyGate: BSgate(0.1, 0.2) | [0, a]; end;",
                 [
                     (
-                        "Definition 'MyGate' is invalid. Only integer wires can be applied when "
-                        "not declaring wires."
+                        "Definition 'MyGate' is invalid. Applied wires [0, a] differ from "
+                        "declared wires [0]."
                     )
                 ],
             ),
@@ -250,8 +274,8 @@ class TestValidatorIntegration:
 
         match = self._create_full_match(matches)
         with pytest.raises(xir.validator.ValidationError, match=match):
-            irprog = xir.parse_script(script)
-            xir.Validator(irprog).run()
+            program = xir.parse_script(script)
+            xir.Validator(program).run()
 
     @pytest.mark.parametrize(
         "stmt, matches",
@@ -286,8 +310,8 @@ class TestValidatorIntegration:
                 "obs MyObs: 4.2, X[a] @ Y[0]; end;",
                 [
                     (
-                        "Definition 'MyObs' is invalid. Only integer wires can be applied when "
-                        "not declaring wires."
+                        "Definition 'MyObs' is invalid. Applied wires [a, 0] differ from declared "
+                        "wires [0]."
                     )
                 ],
             ),
@@ -320,8 +344,8 @@ class TestValidatorIntegration:
         stmt = "obs X[0];obs Y[0];obs Z[0];" + stmt
         match = self._create_full_match(matches)
         with pytest.raises(xir.validator.ValidationError, match=match):
-            irprog = xir.parse_script(stmt)
-            xir.Validator(irprog).run()
+            program = xir.parse_script(stmt)
+            xir.Validator(program).run()
 
     @pytest.mark.parametrize(
         "validators, matches",
@@ -388,7 +412,7 @@ class TestValidatorIntegration:
                 MooGate | [0, 2];
             end;
 
-            gate MooGate:
+            gate MooGate[0, 2]:
                 MyGate | [0, 2];  // circular dependency
             end;
 
@@ -398,8 +422,8 @@ class TestValidatorIntegration:
 
         match = self._create_full_match(matches)
         with pytest.raises(xir.validator.ValidationError, match=match):
-            irprog = xir.parse_script(script)
+            program = xir.parse_script(script)
 
-            val = xir.Validator(irprog)
+            val = xir.Validator(program)
             val._validators.update(validators)  # pylint: disable=protected-access
             val.run()

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -119,6 +119,9 @@ class Validator:
         Raises:
             ValidationError: if any issues are found and ``raise_exception`` is ``True``
         """
+        # reset validation messages in case previously run
+        self._validation_messages = []
+
         if self._validators["declarations"]:
             self._check_declarations()
 
@@ -337,27 +340,22 @@ class Validator:
         declared_params: Sequence[Param],
     ) -> None:
         """Checks the names, wires, and parameters for both observable and gate definitions."""
-        if declared_wires and all(isinstance(w, str) for w in declared_wires):
-            if any(isinstance(w, int) for w in applied_wires):
-                msg = (
-                    f"Definition '{name}' is invalid. Only named wires can be applied when "
-                    "declaring named wires."
-                )
-                self._validation_messages.append(msg)
+        any_integer_applied_wires = any(isinstance(w, int) for w in applied_wires)
+        all_string_declared_wires = all(isinstance(w, str) for w in declared_wires)
 
-            if set(applied_wires) != set(declared_wires):
-                applied = ", ".join(map(str, applied_wires))
-                declared = ", ".join(map(str, declared_wires))
-                msg = (
-                    f"Definition '{name}' is invalid. Applied wires [{applied}] differ "
-                    f"from declared wires [{declared}]."
-                )
-                self._validation_messages.append(msg)
-
-        elif not all(isinstance(w, int) for w in applied_wires):
+        if any_integer_applied_wires and all_string_declared_wires:
             msg = (
-                f"Definition '{name}' is invalid. Only integer wires can be applied when "
-                "not declaring wires."
+                f"Definition '{name}' is invalid. Only named wires can be applied when "
+                "declaring named wires."
+            )
+            self._validation_messages.append(msg)
+
+        if not set(applied_wires).issubset(set(declared_wires)):
+            applied = ", ".join(map(str, applied_wires))
+            declared = ", ".join(map(str, declared_wires))
+            msg = (
+                f"Definition '{name}' is invalid. Applied wires [{applied}] differ "
+                f"from declared wires [{declared}]."
             )
             self._validation_messages.append(msg)
 


### PR DESCRIPTION
**Context:**
When definining an observable, the wires where seemingly not passed to the declaration unless explicitly declared.

```pycon
>>> import xir
>>> program = xir.parse_script("obs Z: 1, Z[0]; end;")
>>> observable = program.declarations["obs"][0]
>>> observable.wires
()
```

**Description of the Change:**
* Wires are implicitly added to the declaration if not explicitly declared in a definition.
* The maximum wire value used in a statement withing a definition will be the number of wires declared. E.g., if, within a definition, a single statement is applied on wire 4, then the declared wires will be 0, 1, 2, 3, and 4.
* Validation now checks that applied wires is a subset of declared wires (they don't need to be equal).
* All definitions will have declared wires (either explicitly or implicitly).

**Benefits:**
Wires are now being declared correctly.

**Possible Drawbacks:**
The validation check for incorrectly using string wires without explicitly declaring wires is gone. Instead, integer wires are implicitly declare, causing applied wires with string labels to _not_ be a subset of the declared wires.
```python
program = xir.parse_script("gate foo[0, 1, 2]; gate bar: foo | [0, a]; end;")
val = xir.Validator(program)
val.run()
```
Output:
```
ValidationError: XIR program is invalid: the following issues have been detected:
	-> Definition 'bar' is invalid. Applied wires [0, a] differ from declared wires [0].
```

**Related GitHub Issues:**
None