### PR TITLE
Params for Observables + ... Wire Notation

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -150,11 +150,12 @@ class TestParser:
             simple_script,
         ],
     )
-    def test_parse_and_serialize(self, circuit):
+    def test_parse_and_serialize(self):
         """Test parsing and serializing an XIR script.
 
         Tests parsing, serializing as well as the ``is_equal`` utils function.
         """
+        circuit = qubit_script
         program = xir.parse_script(circuit)
         xir.Validator(program).run()
         result = program.serialize()

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -200,7 +200,11 @@ class TestSerialize:
     @pytest.mark.parametrize("wires", [("w0", "w1"), ("w0",), ("wire0", "anotherWire", "FortyTwo")])
     def test_observables_params_and_wires(self, program, name, params, wires):
         """Tests serializing an XIR program with observables that have both parameters and wires."""
-        stmts = [xir.ObservableStmt(42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])])]
+        stmts = [
+            xir.ObservableStmt(
+                42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])]
+            )
+        ]
         program.add_observable(name, params, wires, stmts)
 
         res = program.serialize()
@@ -213,7 +217,11 @@ class TestSerialize:
     @pytest.mark.parametrize("wires", [("w0", "w1"), ("w0",), ("wire0", "anotherWire", "FortyTwo")])
     def test_observables_no_params(self, program, name, wires):
         """Tests serializing an XIR program with observables that have no parameters."""
-        stmts = [xir.ObservableStmt(42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])])]
+        stmts = [
+            xir.ObservableStmt(
+                42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])]
+            )
+        ]
         program.add_observable(name, [], wires, stmts)
 
         res = program.serialize()
@@ -225,7 +233,11 @@ class TestSerialize:
     @pytest.mark.parametrize("params", [["a", "b"]])
     def test_observables_no_wires(self, program, name, params):
         """Tests serializing an XIR program with observables that have no declared wires."""
-        stmts = [xir.ObservableStmt(42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])])]
+        stmts = [
+            xir.ObservableStmt(
+                42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])]
+            )
+        ]
         program.add_observable(name, params, (), stmts)
 
         res = program.serialize()
@@ -236,7 +248,11 @@ class TestSerialize:
     @pytest.mark.parametrize("name", ["my_op", "op2"])
     def test_observables_no_params_and_no_wires(self, program, name):
         """Tests serializing an XIR program with observables that have no parameters or wires."""
-        stmts = [xir.ObservableStmt(42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])])]
+        stmts = [
+            xir.ObservableStmt(
+                42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])]
+            )
+        ]
         program.add_observable(name, [], (), stmts)
 
         res = program.serialize()

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -5,7 +5,6 @@ from decimal import Decimal
 from typing import Any, Dict, Iterable, List, MutableSet, Sequence
 
 import pytest
-from xir import ObservableFactor
 
 import xir
 
@@ -128,7 +127,7 @@ class TestSerialize:
     def test_observable_stmt(self, program, pref, wires):
         """Tests serializing an XIR program with observable statements."""
         xyz = "XYZ"
-        terms = [ObservableFactor(xyz[i], None, w) for i, w in enumerate(wires)]
+        terms = [xir.ObservableFactor(xyz[i], None, w) for i, w in enumerate(wires)]
         terms_str = " @ ".join(str(t) for t in terms)
         wires_str = ", ".join(wires)
 
@@ -202,7 +201,7 @@ class TestSerialize:
         """Tests serializing an XIR program with observables that have both parameters and wires."""
         stmts = [
             xir.ObservableStmt(
-                42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])]
+                42, [xir.ObservableFactor("X", None, [0]), xir.ObservableFactor("Y", None, [1])]
             )
         ]
         program.add_observable(name, params, wires, stmts)
@@ -219,7 +218,7 @@ class TestSerialize:
         """Tests serializing an XIR program with observables that have no parameters."""
         stmts = [
             xir.ObservableStmt(
-                42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])]
+                42, [xir.ObservableFactor("X", None, [0]), xir.ObservableFactor("Y", None, [1])]
             )
         ]
         program.add_observable(name, [], wires, stmts)
@@ -235,7 +234,7 @@ class TestSerialize:
         """Tests serializing an XIR program with observables that have no declared wires."""
         stmts = [
             xir.ObservableStmt(
-                42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])]
+                42, [xir.ObservableFactor("X", None, [0]), xir.ObservableFactor("Y", None, [1])]
             )
         ]
         program.add_observable(name, params, (), stmts)
@@ -250,7 +249,7 @@ class TestSerialize:
         """Tests serializing an XIR program with observables that have no parameters or wires."""
         stmts = [
             xir.ObservableStmt(
-                42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])]
+                42, [xir.ObservableFactor("X", None, [0]), xir.ObservableFactor("Y", None, [1])]
             )
         ]
         program.add_observable(name, [], (), stmts)

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -127,14 +127,14 @@ class TestSerialize:
     def test_observable_stmt(self, program, pref, wires):
         """Tests serializing an XIR program with observable statements."""
         xyz = "XYZ"
-        terms = [xir.ObservableFactor(xyz[i], None, w) for i, w in enumerate(wires)]
-        terms_str = " @ ".join(str(t) for t in terms)
+        factors = [xir.ObservableFactor(xyz[i], None, w) for i, w in enumerate(wires)]
+        factors_str = " @ ".join(str(t) for t in factors)
         wires_str = ", ".join(wires)
 
-        program.add_observable("H", ["a", "b"], wires, [xir.ObservableStmt(pref, terms)])
+        program.add_observable("H", ["a", "b"], wires, [xir.ObservableStmt(pref, factors)])
 
         res = program.serialize()
-        assert res == f"obs H(a, b)[{wires_str}]:\n    {pref}, {terms_str};\nend;"
+        assert res == f"obs H(a, b)[{wires_str}]:\n    {pref}, {factors_str};\nend;"
 
     #########################
     # Test gate definitions

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -5,6 +5,7 @@ from decimal import Decimal
 from typing import Any, Dict, Iterable, List, MutableSet, Sequence
 
 import pytest
+from xir import ObservableFactor
 
 import xir
 
@@ -127,8 +128,8 @@ class TestSerialize:
     def test_observable_stmt(self, program, pref, wires):
         """Tests serializing an XIR program with observable statements."""
         xyz = "XYZ"
-        terms = [(xyz[i], w) for i, w in enumerate(wires)]
-        terms_str = " @ ".join(f"{t[0]}[{t[1]}]" for t in terms)
+        terms = [ObservableFactor(xyz[i], None, w) for i, w in enumerate(wires)]
+        terms_str = " @ ".join(str(t) for t in terms)
         wires_str = ", ".join(wires)
 
         program.add_observable("H", ["a", "b"], wires, [xir.ObservableStmt(pref, terms)])
@@ -199,7 +200,7 @@ class TestSerialize:
     @pytest.mark.parametrize("wires", [("w0", "w1"), ("w0",), ("wire0", "anotherWire", "FortyTwo")])
     def test_observables_params_and_wires(self, program, name, params, wires):
         """Tests serializing an XIR program with observables that have both parameters and wires."""
-        stmts = [xir.ObservableStmt(42, [("X", 0), ("Y", 1)])]
+        stmts = [xir.ObservableStmt(42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])])]
         program.add_observable(name, params, wires, stmts)
 
         res = program.serialize()
@@ -212,7 +213,7 @@ class TestSerialize:
     @pytest.mark.parametrize("wires", [("w0", "w1"), ("w0",), ("wire0", "anotherWire", "FortyTwo")])
     def test_observables_no_params(self, program, name, wires):
         """Tests serializing an XIR program with observables that have no parameters."""
-        stmts = [xir.ObservableStmt(42, [("X", 0), ("Y", 1)])]
+        stmts = [xir.ObservableStmt(42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])])]
         program.add_observable(name, [], wires, stmts)
 
         res = program.serialize()
@@ -224,7 +225,7 @@ class TestSerialize:
     @pytest.mark.parametrize("params", [["a", "b"]])
     def test_observables_no_wires(self, program, name, params):
         """Tests serializing an XIR program with observables that have no declared wires."""
-        stmts = [xir.ObservableStmt(42, [("X", 0), ("Y", 1)])]
+        stmts = [xir.ObservableStmt(42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])])]
         program.add_observable(name, params, (), stmts)
 
         res = program.serialize()
@@ -235,7 +236,7 @@ class TestSerialize:
     @pytest.mark.parametrize("name", ["my_op", "op2"])
     def test_observables_no_params_and_no_wires(self, program, name):
         """Tests serializing an XIR program with observables that have no parameters or wires."""
-        stmts = [xir.ObservableStmt(42, [("X", 0), ("Y", 1)])]
+        stmts = [xir.ObservableStmt(42, [ObservableFactor("X", None, [0]), ObservableFactor("Y", None, [1])])]
         program.add_observable(name, [], (), stmts)
 
         res = program.serialize()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -98,10 +98,10 @@ class TestValidatorIntegration:
                 ],
             ),
             (
-                    "gate Sgate(4.2)[...];",
-                    [
-                        "Declaration 'gate Sgate(4.2)[...]' has parameters which are not strings.",
-                    ],
+                "gate Sgate(4.2)[...];",
+                [
+                    "Declaration 'gate Sgate(4.2)[...]' has parameters which are not strings.",
+                ],
             ),
         ],
     )

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -424,3 +424,32 @@ class TestValidatorIntegration:
             val = xir.Validator(program)
             val._validators.update(validators)  # pylint: disable=protected-access
             val.run()
+
+
+    def test_arbitrary_num_wires(self):
+        script = inspect.cleandoc(
+            """
+            gate Sgate(a, b)[...];
+            gate BSgate(theta, phi)[...];
+            
+            ctrl[1] BSgate(0.1, 0.0) | [0, 2];
+            
+            gate MyGate:
+                Sgate(0.7, 0) | [1];
+                BSgate(0.1, 0.0) | [0, 1];
+                ctrl[1,1] Sgate(0.2, 0) | [0];
+                MooGate | [0, 2];
+            end;
+
+            gate MooGate[0, 2]:
+                Sgate(0, 0) | [0, 2];
+            end;
+
+
+            """
+        )
+        program = xir.parse_script(script)
+
+        val = xir.Validator(program)
+        val._validators.update({"statements": True, "definitions": True})  # pylint: disable=protected-access
+        val.run()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -453,5 +453,5 @@ class TestValidatorIntegration:
         val = xir.Validator(program)
         val._validators.update(  # pylint: disable=protected-access
             {"statements": True, "definitions": True}
-        ) 
+        )
         val.run()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -97,6 +97,12 @@ class TestValidatorIntegration:
                     "Declaration 'gate Sgate(4.2)[1]' has parameters which are not strings.",
                 ],
             ),
+            (
+                    "gate Sgate(4.2)[...];",
+                    [
+                        "Declaration 'gate Sgate(4.2)[...]' has parameters which are not strings.",
+                    ],
+            ),
         ],
     )
     def test_check_declarations(self, decl, matches):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -426,13 +426,14 @@ class TestValidatorIntegration:
             val.run()
 
     def test_arbitrary_num_wires(self):
+        """Test whether arbitrary num wires works with different numbers of wires"""
         script = inspect.cleandoc(
             """
             gate Sgate(a, b)[...];
             gate BSgate(theta, phi)[...];
-            
+
             ctrl[1] BSgate(0.1, 0.0) | [0, 2];
-            
+
             gate MyGate:
                 Sgate(0.7, 0) | [1];
                 BSgate(0.1, 0.0) | [0, 1];
@@ -450,7 +451,7 @@ class TestValidatorIntegration:
         program = xir.parse_script(script)
 
         val = xir.Validator(program)
-        val._validators.update(
+        val._validators.update(  # pylint: disable=protected-access
             {"statements": True, "definitions": True}
-        )  # pylint: disable=protected-access
+        ) 
         val.run()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -425,7 +425,6 @@ class TestValidatorIntegration:
             val._validators.update(validators)  # pylint: disable=protected-access
             val.run()
 
-
     def test_arbitrary_num_wires(self):
         script = inspect.cleandoc(
             """
@@ -451,5 +450,7 @@ class TestValidatorIntegration:
         program = xir.parse_script(script)
 
         val = xir.Validator(program)
-        val._validators.update({"statements": True, "definitions": True})  # pylint: disable=protected-access
+        val._validators.update(
+            {"statements": True, "definitions": True}
+        )  # pylint: disable=protected-access
         val.run()

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -39,16 +39,15 @@ def parse_script(script: str, debug: bool = False, **kwargs) -> Program:
     """
 
     if debug:
-        parser = lark.Lark(
+        debug_parser = lark.Lark(
             grammar=_read_lark_file(),
             maybe_placeholders=True,
             start="program",
             parser="lalr",
             debug=True,
         )
-        tree = parser.parse(script)
+        tree = debug_parser.parse(script)
         return Transformer(**kwargs).transform(tree)
-
     parser = lark.Lark(
         grammar=_read_lark_file(),
         maybe_placeholders=True,

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -48,7 +48,8 @@ def _get_parser(debug: bool = False, **kwargs):
     )
 
     # TODO: for non-debug mode, add the transformer as an argument to the parser.
-    # This change would produce an additional speedup, although requires changing the Transformer class to be
+    # This change would produce an additional speedup,
+    # although requires changing the Transformer class to be
     # stateless. (would need to remove self._program)
 
     def _inner_script_parser(script):

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -26,6 +26,7 @@ def _read_lark_file() -> str:
     with path.open("r") as file:
         return file.read()
 
+
 @lru_cache()
 def _get_parser(debug: bool = False, **kwargs):
     """
@@ -38,6 +39,7 @@ def _get_parser(debug: bool = False, **kwargs):
     Returns:
         a parsing function.
     """
+
     def _inner_script_parser(script):
         """
         Parse a script.
@@ -67,6 +69,7 @@ def _get_parser(debug: bool = False, **kwargs):
             transformer=Transformer(**kwargs),
         )
         return parser.parse(script)
+
     return _inner_script_parser
 
 

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 from functools import lru_cache
+from pathlib import Path
 
 from lark import lark
 

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -29,10 +29,11 @@ def parse_script(script: str, debug: bool = False, **kwargs) -> Program:
     """
     Parses an XIR script into a structured :class:`xir.Program`.
 
-    script (str): xir script as a string.
-    debug (bool): if false lark tree building will be skipped, and lark rule collisions will not be
-    given a warning.
-    kwargs: options to be passed to the transformer.
+    Args:
+        script (str): xir script as a string.
+        debug (bool): if false lark tree building will be skipped, and lark rule collisions will not be
+        given a warning.
+        kwargs: options to be passed to the transformer.
     """
 
     if debug:

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -32,7 +32,8 @@ def parse_script(script: str, debug: bool = False, **kwargs) -> Program:
 
     Args:
         script (str): xir script as a string.
-        debug (bool): if false lark tree building will be skipped, and lark rule collisions will not be
+        debug (bool): if false lark tree building will be skipped, and lark rule collisions
+        will not be
         given a warning.
         kwargs: options to be passed to the transformer.
     """
@@ -47,13 +48,13 @@ def parse_script(script: str, debug: bool = False, **kwargs) -> Program:
         )
         tree = parser.parse(script)
         return Transformer(**kwargs).transform(tree)
-    else:
-        parser = lark.Lark(
-            grammar=_read_lark_file(),
-            maybe_placeholders=True,
-            start="program",
-            parser="lalr",
-            debug=False,
-            transformer=Transformer(**kwargs),
-        )
-        return parser.parse(script)
+    
+    parser = lark.Lark(
+        grammar=_read_lark_file(),
+        maybe_placeholders=True,
+        start="program",
+        parser="lalr",
+        debug=False,
+        transformer=Transformer(**kwargs),
+    )
+    return parser.parse(script)

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -17,8 +17,15 @@ __all__ = [
 ]
 
 
-def parse_script(script: str, debug=True, **kwargs) -> Program:
-    """Parses an XIR script into a structured :class:`xir.Program`."""
+def parse_script(script: str, debug: bool = True, **kwargs) -> Program:
+    """
+    Parses an XIR script into a structured :class:`xir.Program`.
+
+    script (str): xir script as a string.
+    debug (bool): if false lark tree building will be skipped, and lark rule collisions will not be
+    given a warning.
+    """
+
     if debug:
         parser = lark.Lark(
             grammar=read_lark_file(),

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -17,6 +17,7 @@ __all__ = [
     "Transformer",
 ]
 
+
 def _read_lark_file() -> str:
     """Reads the contents of the XIR Lark grammar file."""
     path = Path(__file__).parent / "xir.lark"
@@ -24,11 +25,7 @@ def _read_lark_file() -> str:
         return file.read()
 
 
-def parse_script(
-        script: str,
-        debug: bool = False,
-        **kwargs
-    ) -> Program:
+def parse_script(script: str, debug: bool = False, **kwargs) -> Program:
     """
     Parses an XIR script into a structured :class:`xir.Program`.
 

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -1,8 +1,9 @@
 from lark import lark
+from pathlib import Path
 
 from ._version import __version__
 from .decimal_complex import DecimalComplex
-from .parser import Transformer, read_lark_file
+from .parser import Transformer
 from .program import Declaration, ObservableStmt, Program, Statement, ObservableFactor
 from .validator import Validator
 
@@ -16,19 +17,30 @@ __all__ = [
     "Transformer",
 ]
 
+def _read_lark_file() -> str:
+    """Reads the contents of the XIR Lark grammar file."""
+    path = Path(__file__).parent / "xir.lark"
+    with path.open("r") as file:
+        return file.read()
 
-def parse_script(script: str, debug: bool = True, **kwargs) -> Program:
+
+def parse_script(
+        script: str,
+        debug: bool = False,
+        **kwargs
+    ) -> Program:
     """
     Parses an XIR script into a structured :class:`xir.Program`.
 
     script (str): xir script as a string.
     debug (bool): if false lark tree building will be skipped, and lark rule collisions will not be
     given a warning.
+    kwargs: options to be passed to the transformer.
     """
 
     if debug:
         parser = lark.Lark(
-            grammar=read_lark_file(),
+            grammar=_read_lark_file(),
             maybe_placeholders=True,
             start="program",
             parser="lalr",
@@ -38,10 +50,11 @@ def parse_script(script: str, debug: bool = True, **kwargs) -> Program:
         return Transformer(**kwargs).transform(tree)
     else:
         parser = lark.Lark(
-            grammar=read_lark_file(),
+            grammar=_read_lark_file(),
             maybe_placeholders=True,
             start="program",
             parser="lalr",
+            debug=False,
             transformer=Transformer(**kwargs),
         )
         return parser.parse(script)

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -1,10 +1,11 @@
-from lark import lark
 from pathlib import Path
+
+from lark import lark
 
 from ._version import __version__
 from .decimal_complex import DecimalComplex
 from .parser import Transformer
-from .program import Declaration, ObservableStmt, Program, Statement, ObservableFactor
+from .program import Declaration, ObservableFactor, ObservableStmt, Program, Statement
 from .validator import Validator
 
 __all__ = [

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -9,11 +9,11 @@ from .validator import Validator
 __all__ = [
     "DecimalComplex",
     "Declaration",
+    "ObservableFactor",
     "ObservableStmt",
     "Program",
     "Statement",
     "Transformer",
-    "ObservableFactor",
 ]
 
 

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -53,13 +53,17 @@ def _get_parser(debug: bool = False, **kwargs):
         a parsing function
     """
 
-    debug_parser = lark.Lark(
+    parser = lark.Lark(
         grammar=_read_lark_file(),
         maybe_placeholders=True,
         start="program",
         parser="lalr",
-        debug=True,
+        debug=debug,
     )
+
+    # TODO: for non-debug mode, add the transformer as an argument to the parser.
+    # This change would produce an additional speedup, although requires changing the Transformer class to be
+    # stateless. (would need to remove self._program)
 
     def _inner_script_parser(script):
         """Parse a script.
@@ -70,19 +74,9 @@ def _get_parser(debug: bool = False, **kwargs):
         Returns:
             xir.Program: program representation of the script
         """
-        parser = lark.Lark(
-            grammar=_read_lark_file(),
-            maybe_placeholders=True,
-            start="program",
-            parser="lalr",
-            debug=False,
-            transformer=Transformer(**kwargs),
-        )
-        
-        if debug:
-            tree = debug_parser.parse(script)
-            return Transformer(**kwargs).transform(tree)
-        return parser.parse(script)
+
+        tree = parser.parse(script)
+        return Transformer(**kwargs).transform(tree)
 
     return _inner_script_parser
 

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -40,6 +40,23 @@ def _get_parser(debug: bool = False, **kwargs):
         a parsing function.
     """
 
+    debug_parser = lark.Lark(
+        grammar=_read_lark_file(),
+        maybe_placeholders=True,
+        start="program",
+        parser="lalr",
+        debug=True,
+    )
+
+    parser = lark.Lark(
+        grammar=_read_lark_file(),
+        maybe_placeholders=True,
+        start="program",
+        parser="lalr",
+        debug=False,
+        transformer=Transformer(**kwargs),
+    )
+
     def _inner_script_parser(script):
         """
         Parse a script.
@@ -50,24 +67,8 @@ def _get_parser(debug: bool = False, **kwargs):
             Program representation of the script.
         """
         if debug:
-            debug_parser = lark.Lark(
-                grammar=_read_lark_file(),
-                maybe_placeholders=True,
-                start="program",
-                parser="lalr",
-                debug=True,
-            )
             tree = debug_parser.parse(script)
             return Transformer(**kwargs).transform(tree)
-
-        parser = lark.Lark(
-            grammar=_read_lark_file(),
-            maybe_placeholders=True,
-            start="program",
-            parser="lalr",
-            debug=False,
-            transformer=Transformer(**kwargs),
-        )
         return parser.parse(script)
 
     return _inner_script_parser

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -44,7 +44,7 @@ def _get_parser(debug: bool = False, **kwargs):
         maybe_placeholders=True,
         start="program",
         parser="lalr",
-        debug=True,
+        debug=debug,
     )
 
     # TODO: for non-debug mode, add the transformer as an argument to the parser.

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -48,7 +48,7 @@ def parse_script(script: str, debug: bool = False, **kwargs) -> Program:
         )
         tree = parser.parse(script)
         return Transformer(**kwargs).transform(tree)
-    
+
     parser = lark.Lark(
         grammar=_read_lark_file(),
         maybe_placeholders=True,

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -33,8 +33,7 @@ def parse_script(script: str, debug: bool = False, **kwargs) -> Program:
     Args:
         script (str): xir script as a string.
         debug (bool): if false lark tree building will be skipped, and lark rule collisions
-        will not be
-        given a warning.
+        will not be given a warning.
         kwargs: options to be passed to the transformer.
     """
 

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -44,7 +44,7 @@ def _get_parser(debug: bool = False, **kwargs):
         maybe_placeholders=True,
         start="program",
         parser="lalr",
-        debug=debug,
+        debug=True,
     )
 
     # TODO: for non-debug mode, add the transformer as an argument to the parser.
@@ -67,7 +67,7 @@ def _get_parser(debug: bool = False, **kwargs):
     return _inner_script_parser
 
 
-def parse_script(script: str, debug: bool = True, **kwargs) -> Program:
+def parse_script(script: str, debug: bool = False, **kwargs) -> Program:
     """Parses an XIR script into a structured :class:`xir.Program`.
 
     Args:

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -25,7 +25,7 @@ def parse_script(script: str, debug=True, **kwargs) -> Program:
             maybe_placeholders=True,
             start="program",
             parser="lalr",
-            debug=True
+            debug=True,
         )
         tree = parser.parse(script)
         return Transformer(**kwargs).transform(tree)
@@ -35,6 +35,6 @@ def parse_script(script: str, debug=True, **kwargs) -> Program:
             maybe_placeholders=True,
             start="program",
             parser="lalr",
-            transformer=Transformer(**kwargs)
+            transformer=Transformer(**kwargs),
         )
         return parser.parse(script)

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -1,4 +1,4 @@
-from functools import lru_cache, partial
+from functools import lru_cache
 from pathlib import Path
 
 from lark import lark
@@ -25,20 +25,6 @@ def _read_lark_file() -> str:
     path = Path(__file__).parent / "xir.lark"
     with path.open("r") as file:
         return file.read()
-
-def _inner_script_parser(debug_parser, parser, debug, kwargs, script):
-    """
-    Parse a script.
-
-    Args:
-        script (str): xir script as a string.
-    Returns:
-        Program representation of the script.
-    """
-    if debug:
-        tree = debug_parser.parse(script)
-        return Transformer(**kwargs).transform(tree)
-    return parser.parse(script)
 
 
 @lru_cache()
@@ -81,7 +67,7 @@ def _get_parser(debug: bool = False, **kwargs):
     return _inner_script_parser
 
 
-def parse_script(script: str, debug: bool = False, **kwargs) -> Program:
+def parse_script(script: str, debug: bool = True, **kwargs) -> Program:
     """Parses an XIR script into a structured :class:`xir.Program`.
 
     Args:

--- a/xir/__init__.py
+++ b/xir/__init__.py
@@ -35,6 +35,8 @@ def _get_parser(debug: bool = False, **kwargs):
         debug (bool): if false lark tree building will be skipped, and lark rule collisions
         will not be given a warning.
         kwargs: options to be passed to the transformer.
+    Returns:
+        a parsing function.
     """
     def _inner_script_parser(script):
         """
@@ -42,6 +44,8 @@ def _get_parser(debug: bool = False, **kwargs):
 
         Args:
             script (str): xir script as a string.
+        Returns:
+            Program representation of the script.
         """
         if debug:
             debug_parser = lark.Lark(
@@ -75,5 +79,7 @@ def parse_script(script: str, debug: bool = False, **kwargs) -> Program:
         debug (bool): if false lark tree building will be skipped, and lark rule collisions
         will not be given a warning.
         kwargs: options to be passed to the transformer.
+    Returns:
+        Program representation of the script.
     """
     return _get_parser(debug, **kwargs)(script)

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -259,7 +259,8 @@ class Transformer(lark.Transformer):
 
     @v_args(inline=True)
     def obs_stmt(self, pref, factors):
-        """Observable statement. Defined inside an observable definition."""
+        """observable statement. create an ObservableStmt from prefactor and factors.
+        """
         return ObservableStmt(simplify_math(pref), factors, use_floats=self.use_floats)
 
     def obs_group(self, factors):
@@ -267,7 +268,8 @@ class Transformer(lark.Transformer):
 
     @v_args(inline=True)
     def obs_factor(self, name, params, wires):
-        """Obs Factor. add obs factor to a dec"""
+        """ create ObservableFactor from name, params and wires.
+        """
         return ObservableFactor(name, params, wires)
 
     ################
@@ -289,6 +291,7 @@ class Transformer(lark.Transformer):
         self._program.add_declaration(decl)
 
     def wire_list(self, args):
+        """list of wires"""
         return args
 
     def ARBITRARY_NUM_WIRES(self, _):

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -259,7 +259,7 @@ class Transformer(lark.Transformer):
 
     @v_args(inline=True)
     def obs_stmt(self, pref, factors):
-        """observable statement. create an ObservableStmt from prefactor and factors."""
+        """create an ObservableStmt from prefactor and factors."""
         return ObservableStmt(simplify_math(pref), factors, use_floats=self.use_floats)
 
     def obs_group(self, factors):
@@ -297,7 +297,7 @@ class Transformer(lark.Transformer):
 
     @v_args(inline=True)
     def func_decl(self, name, params):
-        """Function declaration. Adds declaration to program."""
+        """Function declaration. Adds function declaration to program."""
         params = params[1] if params else []
         decl = Declaration(name, type_="func", params=params)
         self._program.add_declaration(decl)

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -26,12 +26,8 @@ class Transformer(lark.Transformer):
     def __init__(self, *args, **kwargs):
         self._eval_pi = kwargs.pop("eval_pi", False)
         self._use_floats = kwargs.pop("use_floats", True)
-        self._program = None
-        super().__init__(*args, **kwargs)
-
-    def _transform_tree(self, tree):
         self._program = Program()
-        return super()._transform_tree(tree)
+        super().__init__(*args, **kwargs)
 
     @property
     def eval_pi(self) -> bool:  # pylint: disable=used-before-assignment

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -228,6 +228,8 @@ class Transformer(lark.Transformer):
     @v_args(inline=True)
     def obs_def(self, name, params, wires, statements):
         """
+        Create an observable definition.
+
         Creates an observable definition from text of the form:
 
         .. code-block:: text
@@ -235,13 +237,13 @@ class Transformer(lark.Transformer):
             obs my_obs(params)[0, 1]:
                 1, obs_1[0];
                 0.5, obs_2[1];
-            end;`
+            end;
 
         Args:
-            name: observable name.
-            params: observable params.
-            wires: observable wires.
-            statements: list of statements.
+            name: observable name
+            params: observable params
+            wires: observable wires
+            statements: list of statements
 
         """
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -12,6 +12,7 @@ from .utils import simplify_math
 
 ENUM_WIRES = "ENUM_WIRES"
 
+
 def read_lark_file() -> str:
     """Reads the contents of the XIR Lark grammar file."""
     path = Path(__file__).parent / "xir.lark"
@@ -177,12 +178,7 @@ class Transformer(lark.Transformer):
     def gate_def(self, name, params_list, wires, *stmts):
         """Gate definition. Starts with keyword 'gate'. Adds gate to program."""
 
-        has_declared_wires = False
-        if wires is not None and len(wires) > 0:
-            has_declared_wires = True
-
-
-        if not has_declared_wires:
+        if wires is None:
             max_wire = 0
             for stmt in stmts:
                 int_wires = [w for w in stmt.wires if isinstance(w, int)]

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -26,9 +26,12 @@ class Transformer(lark.Transformer):
     def __init__(self, *args, **kwargs):
         self._eval_pi = kwargs.pop("eval_pi", False)
         self._use_floats = kwargs.pop("use_floats", True)
-
-        self._program = Program()
+        self._program = None
         super().__init__(*args, **kwargs)
+
+    def _transform_tree(self, tree):
+        self._program = Program()
+        return super()._transform_tree(tree)
 
     @property
     def eval_pi(self) -> bool:  # pylint: disable=used-before-assignment

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -7,12 +7,12 @@ from lark import v_args
 
 from .decimal_complex import DecimalComplex
 from .program import (
+    ARBITRARY_NUM_WIRES,
     Declaration,
+    ObservableFactor,
     ObservableStmt,
     Program,
     Statement,
-    ObservableFactor,
-    ARBITRARY_NUM_WIRES,
 )
 from .utils import simplify_math
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -278,7 +278,7 @@ class Transformer(lark.Transformer):
 
     @v_args(inline=True)
     def obs_factor(self, name, params, wires):
-        """create ObservableFactor from name, params and wires."""
+        """Create ``ObservableFactor`` from name, params and wires."""
         params = params[1] if params else []
         return ObservableFactor(name, params, wires)
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -7,7 +7,14 @@ import lark
 from lark import v_args
 
 from .decimal_complex import DecimalComplex
-from .program import Declaration, ObservableStmt, Program, Statement, ObservableFactor, ARBITRARY_NUM_WIRES
+from .program import (
+    Declaration,
+    ObservableStmt,
+    Program,
+    Statement,
+    ObservableFactor,
+    ARBITRARY_NUM_WIRES,
+)
 from .utils import simplify_math
 
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -243,8 +243,9 @@ class Transformer(lark.Transformer):
         return Statement(name, params, wires, **stmt_options)
 
     @v_args(inline=True)
-    def obs_def(self, name, param_list, wires, statements):
-        self._program.add_observable(name, param_list, wires, statements)
+    def obs_def(self, name, params, wires, statements):
+        params = tuple(params[1]) if params is not None else tuple()
+        self._program.add_observable(name, params, wires, statements)
 
     def obs_stmt_list(self, stmts):
         return stmts

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -277,6 +277,7 @@ class Transformer(lark.Transformer):
     @v_args(inline=True)
     def obs_factor(self, name, params, wires):
         """create ObservableFactor from name, params and wires."""
+        params = params[1] if params else []
         return ObservableFactor(name, params, wires)
 
     ################

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -6,13 +6,7 @@ import lark
 from lark import v_args
 
 from .decimal_complex import DecimalComplex
-from .program import (
-    Declaration,
-    ObservableFactor,
-    ObservableStmt,
-    Program,
-    Statement,
-)
+from .program import Declaration, ObservableFactor, ObservableStmt, Program, Statement
 from .utils import simplify_math
 
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -255,6 +255,7 @@ class Transformer(lark.Transformer):
         self._program.add_observable(name, params, wires, statements)
 
     def obs_stmt_list(self, stmts):
+        """Observable statement list"""
         return stmts
 
     @v_args(inline=True)
@@ -263,6 +264,7 @@ class Transformer(lark.Transformer):
         return ObservableStmt(simplify_math(pref), factors, use_floats=self.use_floats)
 
     def obs_group(self, factors):
+        "Observable Factors"
         return factors
 
     @v_args(inline=True)
@@ -293,6 +295,7 @@ class Transformer(lark.Transformer):
         return args
 
     def ARBITRARY_NUM_WIRES(self, _):
+        """Arbitrary number of wires."""
         return ARBITRARY_NUM_WIRES
 
     @v_args(inline=True)

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -221,7 +221,7 @@ class Transformer(lark.Transformer):
             if a == "inv":
                 inverse = not inverse
             elif a == "ctrl":
-                ctrl_wires.update(args.pop(0)[1])
+                ctrl_wires.update(args.pop(0))
 
         name = args.pop(0)
         if is_param(args[0]):

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -228,13 +228,13 @@ class Transformer(lark.Transformer):
     @v_args(inline=True)
     def obs_def(self, name, params, wires, statements):
         """
-            obs def, creates an observable def from xir text of the form:
-            `obs my_obs(params)[0]: 1, obs_1[0]; 0.5, obs_2[1]; end;
+        obs def, creates an observable def from xir text of the form:
+        `obs my_obs(params)[0]: 1, obs_1[0]; 0.5, obs_2[1]; end;
 
-            name: observable name.
-            params: observable params.
-            wires: observable wires.
-            statements: list of statements.
+        name: observable name.
+        params: observable params.
+        wires: observable wires.
+        statements: list of statements.
 
         """
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -7,7 +7,6 @@ from lark import v_args
 
 from .decimal_complex import DecimalComplex
 from .program import (
-    ARBITRARY_NUM_WIRES,
     Declaration,
     ObservableFactor,
     ObservableStmt,
@@ -306,7 +305,7 @@ class Transformer(lark.Transformer):
 
     def ARBITRARY_NUM_WIRES(self, _):
         """Arbitrary number of wires."""
-        return ARBITRARY_NUM_WIRES
+        return ...
 
     @v_args(inline=True)
     def func_decl(self, name, params):

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -264,7 +264,7 @@ class Transformer(lark.Transformer):
         return ObservableStmt(simplify_math(pref), factors, use_floats=self.use_floats)
 
     def obs_group(self, factors):
-        "Observable Factors"
+        """Observable Factors"""
         return factors
 
     @v_args(inline=True)

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -228,8 +228,7 @@ class Transformer(lark.Transformer):
 
     @v_args(inline=True)
     def obs_def(self, name, params, wires, statements):
-        """
-        Create an observable definition.
+        """Create an observable definition.
 
         Creates an observable definition from text of the form:
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -177,7 +177,6 @@ class Transformer(lark.Transformer):
     def gate_def(self, name, params_list, wires, *stmts):
         """Gate definition. Starts with keyword 'gate'. Adds gate to program."""
 
-        max_wire = 0
         has_declared_wires = False
         if wires is not None and len(wires) > 0:
             has_declared_wires = True
@@ -235,6 +234,20 @@ class Transformer(lark.Transformer):
 
     @v_args(inline=True)
     def obs_def(self, name, params, wires, statements):
+
+        if wires is None:
+            max_wire = 0
+            for stmt in statements:
+                for factor in stmt.factors:
+                    int_wires = [w for w in factor.wires if isinstance(w, int)]
+                    if int_wires and max(int_wires) > max_wire:
+                        max_wire = max(int_wires)
+
+            wires = tuple(range(max_wire + 1))
+        else:
+            # remove duplicate wires while maintaining order
+            wires = tuple(dict.fromkeys(wires))
+
         params = tuple(params[1]) if params is not None else tuple()
         self._program.add_observable(name, params, wires, statements)
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -267,12 +267,14 @@ class Transformer(lark.Transformer):
     @v_args(inline=True)
     def gate_decl(self, name, params, wires):
         """Gate declaration. Adds declaration to program."""
+        params = tuple(params[1]) if params is not None else tuple()
         decl = Declaration(name, type_="gate", params=params, wires=wires)
         self._program.add_declaration(decl)
 
     @v_args(inline=True)
     def obs_decl(self, name, params, wires):
         """Observable declaration. Adds declaration to program."""
+        params = tuple(params[1]) if params is not None else tuple()
         decl = Declaration(name, type_="obs", params=params, wires=wires)
         self._program.add_declaration(decl)
 
@@ -285,12 +287,14 @@ class Transformer(lark.Transformer):
     @v_args(inline=True)
     def func_decl(self, name, params):
         """Function declaration. Adds declaration to program."""
+        params = tuple(params[1]) if params is not None else tuple()
         decl = Declaration(name, type_="func", params=params)
         self._program.add_declaration(decl)
 
     @v_args(inline=True)
     def out_decl(self, name, params, wires):
         """Output declaration. Adds declaration to program."""
+        params = tuple(params[1]) if params is not None else tuple()
         decl = Declaration(name, type_="out", params=params, wires=wires)
         self._program.add_declaration(decl)
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -229,12 +229,13 @@ class Transformer(lark.Transformer):
     def obs_def(self, name, params, wires, statements):
         """
         obs def, creates an observable def from xir text of the form:
-        `obs my_obs(params)[0]: 1, obs_1[0]; 0.5, obs_2[1]; end;
+        `obs my_obs(params)[0]: 1, obs_1[0]; 0.5, obs_2[1]; end;`
 
-        name: observable name.
-        params: observable params.
-        wires: observable wires.
-        statements: list of statements.
+        Args:
+            name: observable name.
+            params: observable params.
+            wires: observable wires.
+            statements: list of statements.
 
         """
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -259,8 +259,7 @@ class Transformer(lark.Transformer):
 
     @v_args(inline=True)
     def obs_stmt(self, pref, factors):
-        """observable statement. create an ObservableStmt from prefactor and factors.
-        """
+        """observable statement. create an ObservableStmt from prefactor and factors."""
         return ObservableStmt(simplify_math(pref), factors, use_floats=self.use_floats)
 
     def obs_group(self, factors):
@@ -268,8 +267,7 @@ class Transformer(lark.Transformer):
 
     @v_args(inline=True)
     def obs_factor(self, name, params, wires):
-        """ create ObservableFactor from name, params and wires.
-        """
+        """create ObservableFactor from name, params and wires."""
         return ObservableFactor(name, params, wires)
 
     ################

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -256,14 +256,9 @@ class Transformer(lark.Transformer):
     # declarations
     ################
 
-    def gate_decl(self, args):
+    @v_args(inline=True)
+    def gate_decl(self, name, params, wires):
         """Gate declaration. Adds declaration to program."""
-        if len(args) == 3:
-            name, params, wires = args[0], args[1][1], args[2]
-        else:
-            name, wires = args[0], args[1]
-            params = []
-
         decl = Declaration(name, type_="gate", params=params, wires=wires)
         self._program.add_declaration(decl)
 
@@ -279,26 +274,15 @@ class Transformer(lark.Transformer):
     def ENUM(self, _):
         return ENUM_WIRES
 
-
-    def func_decl(self, args):
+    @v_args(inline=True)
+    def func_decl(self, name, params):
         """Function declaration. Adds declaration to program."""
-        if len(args) == 2:
-            name, params = args[0], args[1][1]
-        else:
-            name = args[0]
-            params = []
-
         decl = Declaration(name, type_="func", params=params)
         self._program.add_declaration(decl)
 
-    def out_decl(self, args):
+    @v_args(inline=True)
+    def out_decl(self, name, params, wires):
         """Output declaration. Adds declaration to program."""
-        if len(args) == 3:
-            name, params, wires = args[0], args[1][1], args[2]
-        else:
-            name, wires = args[0], args[1]
-            params = []
-
         decl = Declaration(name, type_="out", params=params, wires=wires)
         self._program.add_declaration(decl)
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -229,7 +229,7 @@ class Transformer(lark.Transformer):
     def obs_def(self, name, params, wires, statements):
         """
         Creates an observable definition from text of the form:
-        
+
         .. code-block:: text
 
             obs my_obs(params)[0, 1]:

--- a/xir/program.py
+++ b/xir/program.py
@@ -138,16 +138,24 @@ class Statement:
 
 
 class ObservableFactor:
-    def __init__(self, name: str, params: [], wires: [int]):
+    """Observable factor to be used in observable definitions.
+
+    Args:
+        name (str): the name of the factor
+        params ([Any]): the parameters of the factor
+        wires ([int]): the wires this factor acts on
+    """
+    def __init__(self, name: str, params: Params, wires: Sequence[Wire]) -> None:
         self.name = name
         self.params = list(params or [])
-        self.wires = tuple(wires or ())
+        self.wires = list(wires or [])
 
-    def __str__(self):
+    def __str__(self) -> str:
         if len(self.params) == 0:
             return f"{self.name}{self.wires}"
         else:
-            return f"{self.name}({', '.join([str(v) for v in self.params])}){self.wires}"
+            params = ', '.join([str(v) for v in self.params])
+            return f"{self.name}({params}){self.wires}"
 
 
 class ObservableStmt:
@@ -155,7 +163,8 @@ class ObservableStmt:
 
     Args:
         pref (Decimal, int, str): prefactor to the observable terms
-        factors (list): list of observables and the wire(s) they are applied to
+        factors (list[ObservableFactor]): list of observable factors
+        use_floats(bool): whether floats and complex types are returned instead of ``Decimal``
     """
 
     def __init__(

--- a/xir/program.py
+++ b/xir/program.py
@@ -145,6 +145,7 @@ class ObservableFactor:
         params ([Any]): the parameters of the factor
         wires ([int]): the wires this factor acts on
     """
+
     def __init__(self, name: str, params: Params, wires: Sequence[Wire]) -> None:
         self.name = name
         self.params = list(params or [])

--- a/xir/program.py
+++ b/xir/program.py
@@ -150,8 +150,8 @@ class ObservableFactor:
 
     def __init__(self, name: str, params: Params, wires: Sequence[Wire]) -> None:
         self.name = name
-        self.params = list(params or [])
-        self.wires = tuple(wires or [])
+        self.params = params or []
+        self.wires = wires or []
 
     def __str__(self) -> str:
         wires = ", ".join(map(str, self.wires))
@@ -173,7 +173,7 @@ class ObservableStmt:
     def __init__(
         self,
         pref: Union[Decimal, int, str],
-        factors: List[ObservableFactor],
+        factors: Sequence[ObservableFactor],
         use_floats: bool = True,
     ):
         self._pref = pref
@@ -235,10 +235,8 @@ class Declaration:
         self._name = name
         self._type = type_
         self._params = list(params or [])
-        self._any_wires = False
         if wires == ARBITRARY_NUM_WIRES:
             self._wires = ARBITRARY_NUM_WIRES
-            self._any_wires = True
         else:
             self._wires = tuple(wires or ())
 

--- a/xir/program.py
+++ b/xir/program.py
@@ -151,11 +151,11 @@ class ObservableFactor:
         self.wires = tuple(wires or [])
 
     def __str__(self) -> str:
+        wires = ', '.join([str(v) for v in self.wires])
         if len(self.params) == 0:
-            return f"{self.name}{self.wires}"
+            return f"{self.name}[{self.wires}]"
         else:
             params = ', '.join([str(v) for v in self.params])
-            wires = ', '.join([str(v) for v in self.wires])
             return f"{self.name}({params})[{wires}]"
 
 

--- a/xir/program.py
+++ b/xir/program.py
@@ -104,7 +104,7 @@ class Statement:
 
     @property
     def name(self) -> str:
-        """Returns the name of the gate statement."""
+        """Returns the name of the gate statement"""
         return self._name
 
     @property

--- a/xir/program.py
+++ b/xir/program.py
@@ -148,14 +148,15 @@ class ObservableFactor:
     def __init__(self, name: str, params: Params, wires: Sequence[Wire]) -> None:
         self.name = name
         self.params = list(params or [])
-        self.wires = list(wires or [])
+        self.wires = tuple(wires or [])
 
     def __str__(self) -> str:
         if len(self.params) == 0:
             return f"{self.name}{self.wires}"
         else:
             params = ', '.join([str(v) for v in self.params])
-            return f"{self.name}({params}){self.wires}"
+            wires = ', '.join([str(v) for v in self.wires])
+            return f"{self.name}({params})[{wires}]"
 
 
 class ObservableStmt:
@@ -205,7 +206,7 @@ class ObservableStmt:
     @property
     def wires(self) -> Sequence[Wire]:
         """Returns the wires this observable statement is applied to."""
-        return tuple(wires for _, wires in self.factors)
+        return tuple(wire for factor in self.factors for wire in factor.wires)
 
 
 class Declaration:

--- a/xir/program.py
+++ b/xir/program.py
@@ -196,7 +196,7 @@ class ObservableStmt:
         return self._pref
 
     @property
-    def factors(self) -> List:
+    def factors(self) -> Sequence[ObservableStmt]:
         """Returns the terms in this observable statement."""
         return self._factors
 

--- a/xir/program.py
+++ b/xir/program.py
@@ -151,11 +151,11 @@ class ObservableFactor:
         self.wires = tuple(wires or [])
 
     def __str__(self) -> str:
-        wires = ', '.join([str(v) for v in self.wires])
+        wires = ", ".join([str(v) for v in self.wires])
         if len(self.params) == 0:
             return f"{self.name}[{wires}]"
         else:
-            params = ', '.join([str(v) for v in self.params])
+            params = ", ".join([str(v) for v in self.params])
             return f"{self.name}({params})[{wires}]"
 
 

--- a/xir/program.py
+++ b/xir/program.py
@@ -155,7 +155,7 @@ class ObservableFactor:
 
     def __str__(self) -> str:
         wires = ", ".join(map(str, self.wires))
-        if self.params:
+        if not self.params:
             return f"{self.name}[{wires}]"
         params = ", ".join(map(str, self.params))
         return f"{self.name}({params})[{wires}]"

--- a/xir/program.py
+++ b/xir/program.py
@@ -104,7 +104,7 @@ class Statement:
 
     @property
     def name(self) -> str:
-        """Returns the name of the gate statement"""
+        """Returns the name of the statement"""
         return self._name
 
     @property

--- a/xir/program.py
+++ b/xir/program.py
@@ -153,7 +153,7 @@ class ObservableFactor:
     def __str__(self) -> str:
         wires = ', '.join([str(v) for v in self.wires])
         if len(self.params) == 0:
-            return f"{self.name}[{self.wires}]"
+            return f"{self.name}[{wires}]"
         else:
             params = ', '.join([str(v) for v in self.params])
             return f"{self.name}({params})[{wires}]"

--- a/xir/program.py
+++ b/xir/program.py
@@ -535,13 +535,6 @@ class Program:
                 f"Observable '{name}' already defined."
                 "Replacing old definition with new definition."
             )
-        if wires is None:
-            wires = []
-            for statement in statements:
-                for factor in statement.factors:
-                    for wire in factor.wires:
-                        if wire not in wires:
-                            wires.append(wire)
         self.add_declaration(Declaration(name, "obs", params, wires))
         self._observables[name] = statements
 

--- a/xir/program.py
+++ b/xir/program.py
@@ -233,7 +233,7 @@ class Declaration:
         self._name = name
         self._type = type_
         self._params = list(params or [])
-        if ... == wires:
+        if wires == ...:
             self._wires = ...
         else:
             self._wires = tuple(wires or ())

--- a/xir/program.py
+++ b/xir/program.py
@@ -534,7 +534,13 @@ class Program:
                 f"Observable '{name}' already defined."
                 "Replacing old definition with new definition."
             )
-
+        if wires is None:
+            wires = []
+            for statement in statements:
+                for factor in statement.factors:
+                    for wire in factor.wires:
+                        if wire not in wires:
+                            wires.append(wire)
         self.add_declaration(Declaration(name, "obs", params, wires))
         self._observables[name] = statements
 

--- a/xir/program.py
+++ b/xir/program.py
@@ -245,7 +245,7 @@ class Declaration:
             params = "(" + ", ".join(map(str, self.params)) + ")"
         if self.wires:
             if self.wires == ...:
-                wires = f"[...]"
+                wires = "[...]"
             else:
                 wires = "[" + ", ".join(map(str, self.wires)) + "]"
 

--- a/xir/program.py
+++ b/xir/program.py
@@ -24,8 +24,6 @@ Wire = Union[int, str]
 Param = Union[complex, str, Decimal, DecimalComplex, bool, List["Param"]]
 Params = Union[List[Param], Dict[str, Param]]
 
-ARBITRARY_NUM_WIRES = "..."
-
 
 def get_floats(params: Params) -> Params:
     """Converts `decimal.Decimal` and `DecimalComplex` objects to ``float`` and
@@ -227,7 +225,7 @@ class Declaration:
         name: str,
         type_: str,
         params: Optional[Sequence[str]] = None,
-        wires: Optional[Union[Sequence[Wire], ARBITRARY_NUM_WIRES]] = None,
+        wires: Optional[Union[Sequence[Wire], ...]] = None,
     ) -> None:
         if type_ not in ("gate", "out", "obs", "func"):
             raise TypeError(f"Declaration type '{type_}' is invalid.")
@@ -235,8 +233,8 @@ class Declaration:
         self._name = name
         self._type = type_
         self._params = list(params or [])
-        if wires == ARBITRARY_NUM_WIRES:
-            self._wires = ARBITRARY_NUM_WIRES
+        if ... == wires:
+            self._wires = ...
         else:
             self._wires = tuple(wires or ())
 
@@ -246,8 +244,8 @@ class Declaration:
         if self.params:
             params = "(" + ", ".join(map(str, self.params)) + ")"
         if self.wires:
-            if self.wires == ARBITRARY_NUM_WIRES:
-                wires = f"[{ARBITRARY_NUM_WIRES}]"
+            if self.wires == ...:
+                wires = f"[...]"
             else:
                 wires = "[" + ", ".join(map(str, self.wires)) + "]"
 

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -223,9 +223,7 @@ class Validator:
             self._validation_messages.append(msg)
 
         # check that statements are applied to the correct number of wires
-        if ... != declarations[idx].wires and len(stmt.wires) != len(
-            declarations[idx].wires
-        ):
+        if ... != declarations[idx].wires and len(stmt.wires) != len(declarations[idx].wires):
             expected = len(declarations[idx].wires)
             msg = f"Statement '{stmt}' has {len(stmt.wires)} wire(s). Expected {expected}."
             self._validation_messages.append(msg)

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -390,7 +390,8 @@ class Validator:
                 self._validation_messages.append(msg)
 
             # check if invalid observables are applied
-            words, wires = zip(*stmt.factors)
+            words = [factor.name for factor in stmt.factors]
+            wires = tuple(wire for factor in stmt.factors for wire in factor.wires)
             invalid_words = set(words) - {x.name for x in self._program.declarations["obs"]}
             if invalid_words and not (not self._ignore_includes and self.has_includes):
                 msg = (

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -6,7 +6,6 @@ from itertools import chain
 from typing import MutableSet, Optional, Sequence, Union
 
 from xir.decimal_complex import DecimalComplex
-from xir.parser import ARBITRARY_NUM_WIRES
 from xir.program import Declaration, ObservableStmt, Param, Program, Statement, Wire
 
 VALID_CONSTANTS = "PI"
@@ -151,7 +150,7 @@ class Validator:
             * A declaration has parameters which are not strings.
         """
         for decl in (d for l in self._program.declarations.values() for d in l):
-            if decl.wires != ARBITRARY_NUM_WIRES and len(set(decl.wires)) != len(decl.wires):
+            if ... != decl.wires and len(set(decl.wires)) != len(decl.wires):
                 msg = f"Declaration '{decl}' has duplicate wires labels."
                 self._validation_messages.append(msg)
 
@@ -224,7 +223,7 @@ class Validator:
             self._validation_messages.append(msg)
 
         # check that statements are applied to the correct number of wires
-        if declarations[idx].wires != ARBITRARY_NUM_WIRES and len(stmt.wires) != len(
+        if ... != declarations[idx].wires and len(stmt.wires) != len(
             declarations[idx].wires
         ):
             expected = len(declarations[idx].wires)

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -150,7 +150,7 @@ class Validator:
             * A declaration has parameters which are not strings.
         """
         for decl in (d for l in self._program.declarations.values() for d in l):
-            if ... != decl.wires and len(set(decl.wires)) != len(decl.wires):
+            if decl.wires != ... and len(set(decl.wires)) != len(decl.wires):
                 msg = f"Declaration '{decl}' has duplicate wires labels."
                 self._validation_messages.append(msg)
 
@@ -223,7 +223,7 @@ class Validator:
             self._validation_messages.append(msg)
 
         # check that statements are applied to the correct number of wires
-        if ... != declarations[idx].wires and len(stmt.wires) != len(declarations[idx].wires):
+        if declarations[idx].wires != ... and len(stmt.wires) != len(declarations[idx].wires):
             expected = len(declarations[idx].wires)
             msg = f"Statement '{stmt}' has {len(stmt.wires)} wire(s). Expected {expected}."
             self._validation_messages.append(msg)

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -5,9 +5,8 @@ from decimal import Decimal
 from itertools import chain
 from typing import MutableSet, Optional, Sequence, Union
 
-from xir.parser import ARBITRARY_NUM_WIRES
-
 from xir.decimal_complex import DecimalComplex
+from xir.parser import ARBITRARY_NUM_WIRES
 from xir.program import Declaration, ObservableStmt, Param, Program, Statement, Wire
 
 VALID_CONSTANTS = "PI"

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -5,6 +5,8 @@ from decimal import Decimal
 from itertools import chain
 from typing import MutableSet, Optional, Sequence, Union
 
+from xir.parser import ARBITRARY_NUM_WIRES
+
 from xir.decimal_complex import DecimalComplex
 from xir.program import Declaration, ObservableStmt, Param, Program, Statement, Wire
 
@@ -150,7 +152,7 @@ class Validator:
             * A declaration has parameters which are not strings.
         """
         for decl in (d for l in self._program.declarations.values() for d in l):
-            if len(set(decl.wires)) != len(decl.wires):
+            if decl.wires != ARBITRARY_NUM_WIRES and len(set(decl.wires)) != len(decl.wires):
                 msg = f"Declaration '{decl}' has duplicate wires labels."
                 self._validation_messages.append(msg)
 
@@ -223,7 +225,9 @@ class Validator:
             self._validation_messages.append(msg)
 
         # check that statements are applied to the correct number of wires
-        if len(stmt.wires) != len(declarations[idx].wires):
+        if declarations[idx].wires != ARBITRARY_NUM_WIRES and len(stmt.wires) != len(
+            declarations[idx].wires
+        ):
             expected = len(declarations[idx].wires)
             msg = f"Statement '{stmt}' has {len(stmt.wires)} wire(s). Expected {expected}."
             self._validation_messages.append(msg)

--- a/xir/xir.lark
+++ b/xir/xir.lark
@@ -33,7 +33,7 @@ obs_factor: obs [params] wires
 ?obs: name
 
 // wires and parameters
-?wires_or_enum: "[" wire_list "]" | "[" ENUM "]"
+?wires_or_enum: "[" wire_list "]" | "[" ARBITRARY_NUM_WIRES "]"
 ?wires: "[" wire_list "]"
 wire_list : (wire | range_) ("," (wire | range_))*
 ?wire : uint | name
@@ -83,7 +83,7 @@ _OP: "obs"
 _OUT: "out"
 INVERSE: "inv"
 CTRL: "ctrl"
-ENUM: "..."
+ARBITRARY_NUM_WIRES: "..."
 
 _END: "end"
 

--- a/xir/xir.lark
+++ b/xir/xir.lark
@@ -33,8 +33,9 @@ obs_factor: obs [params] wires
 ?obs: name
 
 // wires and parameters
-?wires_or_enum: "[" wire_list "]" | "[" ARBITRARY_NUM_WIRES "]"
+?wires_or_enum: (wires | enum)
 ?wires: "[" wire_list "]"
+?enum: "[" ARBITRARY_NUM_WIRES "]"
 wire_list : (wire | range_) ("," (wire | range_))*
 ?wire : uint | name
 

--- a/xir/xir.lark
+++ b/xir/xir.lark
@@ -21,7 +21,7 @@ func_decl: _FUNC name [params_list] ";"
 
 
 // gates and application statements
-gate_def: _GATE name params_list? wires? ":" application_stmt+ _END ";"
+gate_def: _GATE name [params_list] [wires] ":" application_stmt+ _END ";"
 application_stmt: (INVERSE | (CTRL wires))* name params? "|" wires ";"
 
 // observables

--- a/xir/xir.lark
+++ b/xir/xir.lark
@@ -13,10 +13,10 @@ option: name ":" val
 // declarations
 ?declaration: (gate_decl | obs_decl | func_decl | out_decl)
 
-gate_decl: _GATE name params_list? wires_or_enum ";"
-obs_decl: _OP name params_list? wires_or_enum ";"
-out_decl: _OUT name params_list? wires ";"
-func_decl: _FUNC name params_list? ";"
+gate_decl: _GATE name [params_list] wires_or_enum ";"
+obs_decl: _OP name [params_list] wires_or_enum ";"
+out_decl: _OUT name [params_list] wires ";"
+func_decl: _FUNC name [params_list] ";"
 
 
 

--- a/xir/xir.lark
+++ b/xir/xir.lark
@@ -15,7 +15,7 @@ option: name ":" val
 
 gate_decl: _GATE name [params_list] wires_or_enum ";"
 obs_decl: _OP name [params_list] wires_or_enum ";"
-out_decl: _OUT name [params_list] wires ";"
+out_decl: _OUT name [params_list] wires_or_enum ";"
 func_decl: _FUNC name [params_list] ";"
 
 

--- a/xir/xir.lark
+++ b/xir/xir.lark
@@ -13,9 +13,9 @@ option: name ":" val
 // declarations
 ?declaration: (gate_decl | obs_decl | func_decl | out_decl)
 
-gate_decl: _GATE name [params_list] wires_or_enum ";"
-obs_decl: _OP name [params_list] wires_or_enum ";"
-out_decl: _OUT name [params_list] wires_or_enum ";"
+gate_decl: _GATE name [params_list] wires_or_arbirary ";"
+obs_decl: _OP name [params_list] wires_or_arbirary ";"
+out_decl: _OUT name [params_list] wires_or_arbirary ";"
 func_decl: _FUNC name [params_list] ";"
 
 
@@ -33,9 +33,9 @@ obs_factor: obs [params] wires
 ?obs: name
 
 // wires and parameters
-?wires_or_enum: (wires | enum)
+?wires_or_arbirary: (wires | arbitrary)
 ?wires: "[" wire_list "]"
-?enum: "[" ARBITRARY_NUM_WIRES "]"
+?arbitrary: "[" ARBITRARY_NUM_WIRES "]"
 wire_list : (wire | range_) ("," (wire | range_))*
 ?wire : uint | name
 


### PR DESCRIPTION
This PR does the following

* Allows Observables to contain parameters within observable definitions.
* Implements the ... wire notation for declarations.
* Updates the Transformer to use `v_args(inline=True)` decorator (this combined with using `[expr]` instead of `expr?` in .lark file and `maybe_placeholders=True` option in the parser settings allows for much simpler transformer methods!
* Creates a debug and non-debug mode to run parser in, non debug mode doesn't build parse tree, and increases parse performance in some cases by 30%!
* Refactors `terms` to `factors`