### PR TITLE
Add constants block

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -28,7 +28,7 @@
   [(#2)](https://github.com/XanaduAI/xir/pull/2)
 
 * `xir.Validator` now checks that parameters used in definitions are not also declared constants.
-  [(#7)](https://github.com/XanaduAI/xir/pull/2)
+  [(#7)](https://github.com/XanaduAI/xir/pull/7)
 
 ### Bug Fixes
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,17 +1,17 @@
-## Release 0.2.0 (development release)
+## Release 0.1.1 (development release)
 
 ### New features since last release
 
 ### Improvements
 
 * The maximum wire value used in a statement within a definition will be the number of wires
-  declared. E.g., if, within a definition, a single statement is applied on wire 4, then the
+  declared. For example, if a single statement within a definition is applied to wire 4, then the
   declared wires will be 0, 1, 2, 3, and 4.
   [(#2)](https://github.com/XanaduAI/xir/pull/2)
 
 ### Bug Fixes
 
-* Wires are implicitly added to the declaration if not explicitly declared in a definition.
+* Wires are implicitly added to an observable if they are not explicitly declared.
   [(#2)](https://github.com/XanaduAI/xir/pull/2)
 
 * Validation now checks that applied wires is a subset of declared wires.

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features since last release
 
-* A `constants` block is added to support declaring script-level constants, which can then be used
+* A `constants` block is added to support declaring script level constants, which can then be used
   as parameters in statements.
   [(#7)](https://github.com/XanaduAI/xir/pull/7)
 
@@ -39,7 +39,7 @@
   [(#2)](https://github.com/XanaduAI/xir/pull/2)
 
 * `decimal.Decimal` and `DecimalComplex` objects in nested lists and dictionaries are correctly
-  converted to ``float`` and ``complex`` respectively when using extracted.
+  converted to ``float`` and ``complex`` respectively when extracted.
   [(#7)](https://github.com/XanaduAI/xir/pull/7)
 
 ### Documentation

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,12 +2,33 @@
 
 ### New features since last release
 
+* A `constants` block is added to support declaring script-level constants, which can then be used
+  as parameters in statements.
+  [(#7)](https://github.com/XanaduAI/xir/pull/7)
+
+ ```
+ constants:
+     p0: [3.141592653589793, 4.71238898038469, 0];
+     p1: [1, 0.5, 3.141592653589793];
+     p2: [0, 0, 0];
+ end;
+
+ Sgate(0.123, 4.5) | [2];
+ BSgate(p0, 0.0) | [1, 2];
+ Rgate(p1) | [2];
+ MeasureHomodyne(phi: p0) | [0];
+ """
+ ```
+
 ### Improvements
 
 * The maximum wire value used in a statement within a definition will be the number of wires
   declared. For example, if a single statement within a definition is applied to wire 4, then the
   declared wires will be 0, 1, 2, 3, and 4.
   [(#2)](https://github.com/XanaduAI/xir/pull/2)
+
+* `xir.Validator` now checks that parameters used in definitions are not also declared constants.
+  [(#7)](https://github.com/XanaduAI/xir/pull/2)
 
 ### Bug Fixes
 
@@ -16,6 +37,10 @@
 
 * Validation now checks that applied wires is a subset of declared wires.
   [(#2)](https://github.com/XanaduAI/xir/pull/2)
+
+* `decimal.Decimal` and `DecimalComplex` objects in nested lists and dictionaries are correctly
+  converted to ``float`` and ``complex`` respectively when using extracted.
+  [(#7)](https://github.com/XanaduAI/xir/pull/7)
 
 ### Documentation
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### New features since last release
 
-* A `constants` block is added to support declaring script level constants, which can then be used
+* A `constants` block has been added to support declaring script-level constants which can be used
   as parameters in statements.
   [(#7)](https://github.com/XanaduAI/xir/pull/7)
 
@@ -17,7 +17,6 @@
  BSgate(p0, 0.0) | [1, 2];
  Rgate(p1) | [2];
  MeasureHomodyne(phi: p0) | [0];
- """
  ```
 
 ### Improvements
@@ -27,7 +26,7 @@
   declared wires will be 0, 1, 2, 3, and 4.
   [(#2)](https://github.com/XanaduAI/xir/pull/2)
 
-* `xir.Validator` now checks that parameters used in definitions are not also declared constants.
+* `xir.Validator` now also checks that parameters used in definitions are not declared constants.
   [(#7)](https://github.com/XanaduAI/xir/pull/7)
 
 ### Bug Fixes
@@ -39,7 +38,7 @@
   [(#2)](https://github.com/XanaduAI/xir/pull/2)
 
 * `decimal.Decimal` and `DecimalComplex` objects in nested lists and dictionaries are correctly
-  converted to ``float`` and ``complex`` respectively when extracted.
+  converted to `float` and `complex` respectively when extracted.
   [(#7)](https://github.com/XanaduAI/xir/pull/7)
 
 ### Documentation

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -85,6 +85,7 @@ author = "Xanadu Inc."
 #
 # The full version, including alpha/beta/rc tags.
 import xir
+
 release = xir.__version__
 
 # The short X.Y version.

--- a/docs/use/grammar.rst
+++ b/docs/use/grammar.rst
@@ -22,7 +22,15 @@ is expanded on in detail following some initial examples:
         dimension: 3;
     end;
 
-3. **Declarations.** Declarations of gates, observables, functions, and outputs.
+3. **Constants.** Constants at the global scope.
+
+.. code-block:: text
+
+    constants:
+        parameter_array: [1, 2, 3, 4];
+    end;
+
+4. **Declarations.** Declarations of gates, observables, functions, and outputs.
 
 .. code-block:: text
 
@@ -32,7 +40,7 @@ is expanded on in detail following some initial examples:
     out amplitude(state) [0..2];
 
 
-4. **Definitions.** Definitions of gates and observables.
+5. **Definitions.** Definitions of gates and observables.
 
 .. code-block:: text
 
@@ -42,7 +50,7 @@ is expanded on in detail following some initial examples:
         H | [b];  // Apply a Hadamard to the second wire.
     end;
 
-5. **Statements.** Gate application statements and measurements.
+6. **Statements.** Gate application statements and measurements.
 
 .. code-block:: text
 
@@ -117,8 +125,8 @@ Constants
 ---------
 
 The ``constants`` block provides a way to declare constants that can be referenced
-in other parts of the script. The syntax for specifying constants is analogous to
-that of a (flat) JSON object or Python dictionary.
+as parameter values in other parts of the script. The syntax for specifying constants
+is the same as the ``options`` block (up to the opening keyword).
 
 .. code-block:: text
 

--- a/docs/use/grammar.rst
+++ b/docs/use/grammar.rst
@@ -113,6 +113,22 @@ set of supported options and choose their semantics.
         tags: [experimental, d20];  // Associate some tags with the program result.
     end;
 
+Constants
+---------
+
+The ``constants`` block provides a way to declare constants that can be referenced
+in other parts of the script. The syntax for specifying options is analogous to
+that of a (flat) JSON object or Python dictionary.
+
+.. code-block:: text
+
+    constants:
+        parameter_array: [1, 2, 3, 4];
+        U: [[0.50902901+0.62151867j, -0.50774987+0.31111745j],
+            [0.57730909+0.14600757j,  0.30112128-0.7447966j]]
+        phi: 1.61803398875;
+    end;
+
 Declarations
 ------------
 

--- a/docs/use/grammar.rst
+++ b/docs/use/grammar.rst
@@ -340,8 +340,9 @@ Notes
 Keywords
 --------
 
+* ``constants``: Start of constants block section.
 * ``ctrl``: Control wires modifier for statements.
-* ``end``: End of a definition or options section.
+* ``end``: End of a definition, options or constants section.
 * ``false``: Boolean false.
 * ``func``: Declaration of mathematical functions.
 * ``gate``: Gate declaration or definition.

--- a/docs/use/grammar.rst
+++ b/docs/use/grammar.rst
@@ -331,7 +331,7 @@ Keywords
 * ``gate``: Gate declaration or definition.
 * ``inv``: Inverse modifier for statements.
 * ``obs``: Observable declaration or definition.
-* ``options``: Start of script level options section.
+* ``options``: Start of script-level options section.
 * ``out``: Declaration of measurements and post-processing statistics.
 * ``pi``: Mathematical constant pi (:math:`\pi`).
 * ``true``: Boolean true.

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -19,6 +19,27 @@ Rgate(0.2) | [1];
 MeasureHomodyne(phi: 3) | [0];
 """
 
+tdm_script = """
+use <xc/tdm>;
+
+options:
+    type: tdm;
+    N: [2, 3];
+end;
+
+constants:
+    p0: [3.141592653589793, 4.71238898038469, 0];
+    p1: [1, 0.5, 3.141592653589793];
+    p2: [0, 0, 0];
+end;
+
+Sgate(0.123, 0.7853981633974483) | [2];
+BSgate(p0, 0.0) | [1, 2];
+Rgate(p1) | [2];
+MeasureHomodyne(phi: p0) | [0];
+MeasureHomodyne(phi: p2) | [2];
+"""
+
 photonics_script_no_decl = """
 use photonics_gates;
 
@@ -120,7 +141,14 @@ class TestParser:
 
     @pytest.mark.parametrize(
         "circuit",
-        [qubit_script, photonics_script, photonics_script_no_decl, jet_script, simple_script],
+        [
+            qubit_script,
+            photonics_script,
+            photonics_script_no_decl,
+            tdm_script,
+            jet_script,
+            simple_script,
+        ],
     )
     def test_parse_and_serialize(self, circuit):
         """Test parsing and serializing an XIR script.

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -42,7 +42,7 @@ class TestParser:
         ],
     )
     def test_options(self, key, val, expected):
-        """Test script-level options."""
+        """Test script level options."""
         irprog = parse_script(f"options:\n    {key}: {val};\nend;", use_floats=True, eval_pi=True)
 
         assert key in irprog.options
@@ -57,7 +57,7 @@ class TestParser:
         ],
     )
     def test_options_lists(self, key, val):
-        """Test script-level options with lists."""
+        """Test script level options with lists."""
         val_str = "[" + ", ".join(str(v) for v in val) + "]"
         irprog = parse_script(f"options:\n    {key}: {val_str};\nend;")
 
@@ -77,7 +77,7 @@ class TestParser:
         ],
     )
     def test_constants(self, key, val, expected):
-        """Test script-level constants."""
+        """Test script level constants."""
         irprog = parse_script(f"constants:\n    {key}: {val};\nend;", use_floats=True, eval_pi=True)
 
         assert key in irprog.constants
@@ -92,7 +92,7 @@ class TestParser:
         ],
     )
     def test_constants_lists(self, key, val):
-        """Test script-level constants with lists."""
+        """Test script level constants with lists."""
         val_str = "[" + ", ".join(str(v) for v in val) + "]"
         irprog = parse_script(f"constants:\n    {key}: {val_str};\nend;")
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -80,7 +80,9 @@ class TestParser:
     )
     def test_constants(self, key, val, expected):
         """Test script-level constants."""
-        program = parse_script(f"constants:\n    {key}: {val};\nend;", use_floats=True, eval_pi=True)
+        program = parse_script(
+            f"constants:\n    {key}: {val};\nend;", use_floats=True, eval_pi=True
+        )
         assert key in program.constants
         assert program.constants[key] == expected
 

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -78,10 +78,9 @@ class TestParser:
     )
     def test_constants(self, key, val, expected):
         """Test script level constants."""
-        irprog = parse_script(f"constants:\n    {key}: {val};\nend;", use_floats=True, eval_pi=True)
-
-        assert key in irprog.constants
-        assert irprog.constants[key] == expected
+        program = parse_script(f"constants:\n    {key}: {val};\nend;", use_floats=True, eval_pi=True)
+        assert key in program.constants
+        assert program.constants[key] == expected
 
     @pytest.mark.parametrize(
         "key, val",
@@ -93,11 +92,10 @@ class TestParser:
     )
     def test_constants_lists(self, key, val):
         """Test script level constants with lists."""
-        val_str = "[" + ", ".join(str(v) for v in val) + "]"
-        irprog = parse_script(f"constants:\n    {key}: {val_str};\nend;")
-
-        assert key in irprog.constants
-        assert irprog.constants[key] == val
+        val_str = "[" + ", ".join(map(str, val)) + "]"
+        program = parse_script(f"constants:\n    {key}: {val_str};\nend;")
+        assert key in program.constants
+        assert program.constants[key] == val
 
     @pytest.mark.parametrize(
         "script, inverse",

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -65,6 +65,41 @@ class TestParser:
         assert irprog.options[key] == val
 
     @pytest.mark.parametrize(
+        "key, val, expected",
+        [
+            ("cutoff", "5", 5),
+            ("anything", "4.2", 4.2),
+            ("a_number", "3 + 2.1", 5.1),
+            ("a_number_with_pi", "pi / 2", math.pi / 2),
+            ("a_string", "hello", "hello"),
+            ("True", "False", "False"),
+            ("true", "false", False),
+        ],
+    )
+    def test_constants(self, key, val, expected):
+        """Test script-level constants."""
+        irprog = parse_script(f"constants:\n    {key}: {val};\nend;", use_floats=True, eval_pi=True)
+
+        assert key in irprog.constants
+        assert irprog.constants[key] == expected
+
+    @pytest.mark.parametrize(
+        "key, val",
+        [
+            ("key", ["compound", "value"]),
+            ("True", [1, 2, "False"]),
+            ("key", [1, [2, [3, 4]]]),
+        ],
+    )
+    def test_constants_lists(self, key, val):
+        """Test script-level constants with lists."""
+        val_str = "[" + ", ".join(str(v) for v in val) + "]"
+        irprog = parse_script(f"constants:\n    {key}: {val_str};\nend;")
+
+        assert key in irprog.constants
+        assert irprog.constants[key] == val
+
+    @pytest.mark.parametrize(
         "script, inverse",
         [
             ("inv ry(2.4) | [2];", True),

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -72,6 +72,8 @@ class TestParser:
             ("a_number", "3 + 2.1", 5.1),
             ("a_number_with_pi", "pi / 2", math.pi / 2),
             ("a_string", "hello", "hello"),
+            ("a_string", "PI", "PI"),
+            ("a_string", "obs", "obs"),
             ("True", "False", "False"),
             ("true", "false", False),
         ],

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -42,7 +42,7 @@ class TestParser:
         ],
     )
     def test_options(self, key, val, expected):
-        """Test script level options."""
+        """Test script-level options."""
         irprog = parse_script(f"options:\n    {key}: {val};\nend;", use_floats=True, eval_pi=True)
 
         assert key in irprog.options
@@ -57,7 +57,7 @@ class TestParser:
         ],
     )
     def test_options_lists(self, key, val):
-        """Test script level options with lists."""
+        """Test script-level options with lists."""
         val_str = "[" + ", ".join(str(v) for v in val) + "]"
         irprog = parse_script(f"options:\n    {key}: {val_str};\nend;")
 
@@ -77,7 +77,7 @@ class TestParser:
         ],
     )
     def test_constants(self, key, val, expected):
-        """Test script level constants."""
+        """Test script-level constants."""
         program = parse_script(f"constants:\n    {key}: {val};\nend;", use_floats=True, eval_pi=True)
         assert key in program.constants
         assert program.constants[key] == expected
@@ -91,7 +91,7 @@ class TestParser:
         ],
     )
     def test_constants_lists(self, key, val):
-        """Test script level constants with lists."""
+        """Test script-level constants with lists."""
         val_str = "[" + ", ".join(map(str, val)) + "]"
         program = parse_script(f"constants:\n    {key}: {val_str};\nend;")
         assert key in program.constants

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -475,6 +475,26 @@ class TestProgram:
 
         assert program.options == {"precision": "double"}
 
+    def test_add_constant(self, program):
+        """Tests that constants can be added to an XIR program."""
+        program.add_constant("p0", [1, 2, 3])
+        assert program.constants == {"p0": [1, 2, 3]}
+
+        program.add_constant("golden_ratio", 1.618)
+        assert program.constants == {"p0": [1, 2, 3], "golden_ratio": 1.618}
+
+    def test_add_constant_with_same_key(self, program):
+        """Tests that a warning is issued when two constants with the same key
+        are added to an XIR program.
+        """
+        program.add_constant("p1", [4, 2])
+        assert program.constants == {"p1": [4, 2]}
+
+        with pytest.warns(Warning, match=r"Constant 'p1' already set"):
+            program.add_constant("p1", [3, 14])
+
+        assert program.constants == {"p1": [3, 14]}
+
     def test_add_statement(self, program):
         """Tests that statements can be added to an XIR program."""
         program.add_statement(xir.Statement("X", {}, [0]))

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -167,7 +167,7 @@ class TestValidatorIntegration:
                 [
                     (
                         "Statement 'Sample | [x, y]' is applied to named wires. Only integer wire "
-                        "labels are allowed at a script level."
+                        "labels are allowed at the script level."
                     )
                 ],
             ),

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -77,7 +77,7 @@ class TestValidatorIntegration:
             xir.Validator(program).run()
 
     def test_check_pi_constant(self):
-        """Test that using pi in a constant declaration raise the correct exceptions."""
+        """Test that using pi in a constant declaration raises the correct exception."""
         constants_block = "constants: pi: 123; end;"
         msg = "Constant 'pi' is already defined and cannot be replaced."
 

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -256,6 +256,15 @@ class TestValidatorIntegration:
                     )
                 ],
             ),
+            (
+                "constants: a: 1.23; end; gate MyGate(a): BSgate(a, 0.0) | [0, 1]; end;",
+                [
+                    (
+                        "Definition 'MyGate' is invalid. Cannot use declared constant(s) "
+                        "{'a'} as parameter(s)."
+                    )
+                ],
+            ),
         ],
     )
     def test_check_gate_definitions(self, stmt, matches):

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -167,7 +167,7 @@ class TestValidatorIntegration:
                 [
                     (
                         "Statement 'Sample | [x, y]' is applied to named wires. Only integer wire "
-                        "labels are allowed at a script-level."
+                        "labels are allowed at a script level."
                     )
                 ],
             ),

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -76,6 +76,16 @@ class TestValidatorIntegration:
             program = xir.parse_script(decl)
             xir.Validator(program).run()
 
+    def test_check_pi_constant(self):
+        """Test that using pi in a constant declaration raise the correct exceptions."""
+        constants_block = "constants: pi: 123; end;"
+        msg = "Constant 'pi' is already defined and cannot be replaced."
+
+        match = self._create_full_match([msg])
+        with pytest.raises(xir.validator.ValidationError, match=match):
+            program = xir.parse_script(constants_block)
+            xir.Validator(program).run()
+
     @pytest.mark.parametrize(
         "decl, matches",
         [

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -167,7 +167,7 @@ class TestValidatorIntegration:
                 [
                     (
                         "Statement 'Sample | [x, y]' is applied to named wires. Only integer wire "
-                        "labels are allowed at a script level."
+                        "labels are allowed at a script-level."
                     )
                 ],
             ),

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -69,12 +69,12 @@ class Transformer(lark.Transformer):
                 self._program.add_statement(stmt)
 
     def script_options(self, args):
-        """script-level options. Adds any options to the program."""
+        """Script-level options. Adds any options to the program."""
         for name, value in args:
             self._program.add_option(name, value)
 
     def constants(self, args):
-        """script-level constants. Adds any constant to the program."""
+        """Script-level constants. Adds any constant to the program."""
         for name, value in args:
             self._program.add_constant(name, value)
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -69,12 +69,12 @@ class Transformer(lark.Transformer):
                 self._program.add_statement(stmt)
 
     def script_options(self, args):
-        """Script level options. Adds any options to the program."""
+        """script-level options. Adds any options to the program."""
         for name, value in args:
             self._program.add_option(name, value)
 
     def constants(self, args):
-        """Script level constants. Adds any constant to the program."""
+        """script-level constants. Adds any constant to the program."""
         for name, value in args:
             self._program.add_constant(name, value)
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -73,6 +73,11 @@ class Transformer(lark.Transformer):
         for name, value in args:
             self._program.add_option(name, value)
 
+    def constants(self, args):
+        """Script level constants. Adds any constant to the program."""
+        for name, value in args:
+            self._program.add_constant(name, value)
+
     ###############
     # basic types
     ###############

--- a/xir/program.py
+++ b/xir/program.py
@@ -550,7 +550,7 @@ class Program:
             name (str): name of the constant
             value (Any): value of the constant
         """
-        if name in self._options:
+        if name in self._constants:
             warnings.warn(f"Constant '{name}' already set. Replacing old value with new value.")
 
         self._constants[name] = value

--- a/xir/program.py
+++ b/xir/program.py
@@ -368,10 +368,10 @@ class Program:
 
     @property
     def options(self) -> Mapping[str, Any]:
-        """Returns the script-level options declared in the XIR program.
+        """Returns the script level options declared in the XIR program.
 
         Returns:
-            Mapping[str, Any]: declared script-level options
+            Mapping[str, Any]: declared script level options
         """
         if self.use_floats:
             options_with_floats = get_floats(self._options)
@@ -383,10 +383,10 @@ class Program:
 
     @property
     def constants(self) -> Mapping[str, Any]:
-        """Returns the script-level constants declared in the XIR program.
+        """Returns the script level constants declared in the XIR program.
 
         Returns:
-            Mapping[str, Any]: declared script-level constants
+            Mapping[str, Any]: declared script level constants
         """
         if self.use_floats:
             constants_with_floats = get_floats(self._constants)

--- a/xir/program.py
+++ b/xir/program.py
@@ -35,6 +35,8 @@ def get_floats(params: Params) -> Params:
                 params_with_floats.append(complex(p))
             elif isinstance(p, Decimal):
                 params_with_floats.append(float(p))
+            elif isinstance(p, List):
+                params_with_floats.append(get_floats(p))
             else:
                 params_with_floats.append(p)
 
@@ -45,6 +47,8 @@ def get_floats(params: Params) -> Params:
                 params_with_floats[k] = complex(v)
             elif isinstance(v, Decimal):
                 params_with_floats[k] = float(v)
+            elif isinstance(v, List):
+                params_with_floats[k] = get_floats(v)
             else:
                 params_with_floats[k] = v
 
@@ -266,6 +270,7 @@ class Program:
 
         self._includes = []
         self._options = {}
+        self._constants = {}
         self._statements = []
 
         self._declarations = {key: [] for key in ("gate", "func", "out", "obs")}
@@ -366,7 +371,7 @@ class Program:
         """Returns the script-level options declared in the XIR program.
 
         Returns:
-            Mapping[str, Any]: declared scipt-level options
+            Mapping[str, Any]: declared script-level options
         """
         if self.use_floats:
             options_with_floats = get_floats(self._options)
@@ -375,6 +380,21 @@ class Program:
             if isinstance(options_with_floats, Dict):
                 return options_with_floats
         return self._options
+
+    @property
+    def constants(self) -> Mapping[str, Any]:
+        """Returns the script-level constants declared in the XIR program.
+
+        Returns:
+            Mapping[str, Any]: declared script-level constants
+        """
+        if self.use_floats:
+            constants_with_floats = get_floats(self._constants)
+            # The following condition should always be True. For more context,
+            # see https://github.com/XanaduAI/jet/pull/52/files#r681872696.
+            if isinstance(constants_with_floats, Dict):
+                return constants_with_floats
+        return self._constants
 
     @property
     def statements(self) -> Sequence[Statement]:
@@ -523,6 +543,18 @@ class Program:
 
         self._options[name] = value
 
+    def add_constant(self, name: str, value: Any) -> None:
+        """Adds a constant to the XIR program.
+
+        Args:
+            name (str): name of the constant
+            value (Any): value of the constant
+        """
+        if name in self._options:
+            warnings.warn(f"Constant '{name}' already set. Replacing old value with new value.")
+
+        self._constants[name] = value
+
     def add_statement(self, statement: Statement) -> None:
         """Adds a statement to the XIR program.
 
@@ -560,6 +592,11 @@ class Program:
         if len(self.options) > 0:
             res.append("options:")
             res.extend([f"    {k}: {v};" for k, v in self.options.items()])
+            res.append("end;\n")
+
+        if len(self.constants) > 0:
+            res.append("constants:")
+            res.extend([f"    {k}: {v};" for k, v in self.constants.items()])
             res.append("end;\n")
 
         has_decl = False

--- a/xir/program.py
+++ b/xir/program.py
@@ -368,10 +368,10 @@ class Program:
 
     @property
     def options(self) -> Mapping[str, Any]:
-        """Returns the script level options declared in the XIR program.
+        """Returns the script-level options declared in the XIR program.
 
         Returns:
-            Mapping[str, Any]: declared script level options
+            Mapping[str, Any]: declared script-level options
         """
         if self.use_floats:
             options_with_floats = get_floats(self._options)
@@ -383,10 +383,10 @@ class Program:
 
     @property
     def constants(self) -> Mapping[str, Any]:
-        """Returns the script level constants declared in the XIR program.
+        """Returns the script-level constants declared in the XIR program.
 
         Returns:
-            Mapping[str, Any]: declared script level constants
+            Mapping[str, Any]: declared script-level constants
         """
         if self.use_floats:
             constants_with_floats = get_floats(self._constants)

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -170,13 +170,13 @@ class Validator:
         """Checks that statements are valid.
 
         Checks that all statements have a declaration and that they are correctly applied. If no
-        statements are passed, the script level statements in the program will be used. The
+        statements are passed, the script-level statements in the program will be used. The
         statements will be marked as invalid if:
 
             * A gate application statement specifies the wrong number of wires.
             * A gate application statement specifies the wrong number of parameters.
             * A gate application statement specifies the wrong parameter names.
-            * A gate application statement at the script level is applied to named wires.
+            * A gate application statement at the script-level is applied to named wires.
 
         Checks that modifiers such as ``ctrl`` and ``inv`` are correctly applied.
         The modifiers will be marked as invalid if:
@@ -246,11 +246,11 @@ class Validator:
         Checks the remaining conditions documented (but not implemented) by
         :func:`Validator._check_statements()`.
         """
-        # check that only integer wire labels are used at a script level
+        # check that only integer wire labels are used at a script-level
         if declared_params is None and any(isinstance(wire, str) for wire in stmt.wires):
             msg = (
                 f"Statement '{stmt}' is applied to named wires. Only integer wire labels are "
-                "allowed at a script level."
+                "allowed at a script-level."
             )
             self._validation_messages.append(msg)
 

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -363,7 +363,7 @@ class Validator:
             msg = f"Definition '{name}' is invalid. Wire and parameter names must differ."
             self._validation_messages.append(msg)
 
-        constants_declared = set(declared_params) - set(self._program.constants)
+        constants_declared = set(declared_params).intersection(self._program.constants)
         if constants_declared:
             msg = (
                 f"Definition '{name}' is invalid. Cannot use declared constant(s) "

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -176,7 +176,7 @@ class Validator:
             * A gate application statement specifies the wrong number of wires.
             * A gate application statement specifies the wrong number of parameters.
             * A gate application statement specifies the wrong parameter names.
-            * A gate application statement at the script-level is applied to named wires.
+            * A gate application statement at the script level is applied to named wires.
 
         Checks that modifiers such as ``ctrl`` and ``inv`` are correctly applied.
         The modifiers will be marked as invalid if:
@@ -246,11 +246,11 @@ class Validator:
         Checks the remaining conditions documented (but not implemented) by
         :func:`Validator._check_statements()`.
         """
-        # check that only integer wire labels are used at a script-level
+        # check that only integer wire labels are used at a script level
         if declared_params is None and any(isinstance(wire, str) for wire in stmt.wires):
             msg = (
                 f"Statement '{stmt}' is applied to named wires. Only integer wire labels are "
-                "allowed at a script-level."
+                "allowed at a script level."
             )
             self._validation_messages.append(msg)
 
@@ -359,11 +359,11 @@ class Validator:
             )
             self._validation_messages.append(msg)
 
-        if set(declared_wires).intersection(set(declared_params)):
+        if set(declared_wires) & set(declared_params):
             msg = f"Definition '{name}' is invalid. Wire and parameter names must differ."
             self._validation_messages.append(msg)
 
-        constants_declared = set(declared_params).intersection(self._program.constants)
+        constants_declared = set(declared_params) & set(self._program.constants)
         if constants_declared:
             msg = (
                 f"Definition '{name}' is invalid. Cannot use declared constant(s) "

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -147,7 +147,7 @@ class Validator:
         return self._validation_messages or None
 
     def _check_constants(self) -> None:
-        """Checks that constants are correctly declared."""
+        """Checks that the declared constants are valid."""
         for const in self._program.constants.keys():
             # grammar uses lowercase constants, while the program uses upper-case
             if const in map(str.lower, VALID_CONSTANTS):

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -363,7 +363,7 @@ class Validator:
             msg = f"Definition '{name}' is invalid. Wire and parameter names must differ."
             self._validation_messages.append(msg)
 
-        constants_declared = {p for p in declared_params if p in self._program.constants}
+        constants_declared = set(declared_params) - set(self._program.constants)
         if constants_declared:
             msg = (
                 f"Definition '{name}' is invalid. Cannot use declared constant(s) "

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -363,6 +363,14 @@ class Validator:
             msg = f"Definition '{name}' is invalid. Wire and parameter names must differ."
             self._validation_messages.append(msg)
 
+        constants_declared = {p for p in declared_params if p in self._program.constants}
+        if constants_declared:
+            msg = (
+                f"Definition '{name}' is invalid. Cannot use declared constant(s) "
+                f"{constants_declared} as parameter(s)."
+            )
+            self._validation_messages.append(msg)
+
     def _check_observable_statements(
         self,
         statements: Sequence[ObservableStmt],

--- a/xir/validator.py
+++ b/xir/validator.py
@@ -246,11 +246,11 @@ class Validator:
         Checks the remaining conditions documented (but not implemented) by
         :func:`Validator._check_statements()`.
         """
-        # check that only integer wire labels are used at a script level
+        # check that only integer wire labels are used at the script level
         if declared_params is None and any(isinstance(wire, str) for wire in stmt.wires):
             msg = (
                 f"Statement '{stmt}' is applied to named wires. Only integer wire labels are "
-                "allowed at a script level."
+                "allowed at the script level."
             )
             self._validation_messages.append(msg)
 

--- a/xir/xir.lark
+++ b/xir/xir.lark
@@ -1,13 +1,14 @@
 // XIR grammar
 program: include* circuit
-circuit: (script_options | declaration | gate_def | obs_def | application_stmt)*
+circuit: (script_options | constants | declaration | gate_def | obs_def | application_stmt)*
 
 // includes
 include: "use" (path | ANGLE_L path ANGLE_R) ";"
 path: /[-.:_a-zA-Z0-9\/]+/
 
-// script options
+// script options and constants
 script_options: _OPTIONS ":" (option ";")+ _END ";"
+constants: _CONSTANTS ":" (option ";")+ _END ";"
 option: name ":" val
 
 // declarations
@@ -71,6 +72,7 @@ range_: INT ".." INT
 PI: "pi"
 
 _OPTIONS: "options"
+_CONSTANTS: "constants"
 _GATE: "gate"
 _FUNC: "func"
 _OP: "obs"


### PR DESCRIPTION
**Context:**
Defining constants would greatly simplify the way that TDM programs can be converted to/from XIR scripts.

**Description of the Change:**
The grammar and parser are updated to support a new "constants" block (similar to the already existing "options" block). Within a "constants" block constants can be defined, which can later be used in statements. 

The following is an example of a TDM program written in XIR.
```
use <xc/tdm>;

options:
    type: tdm;
    N: [2, 3];
end;

constants:
    p0: [3.141592653589793, 4.71238898038469, 0];
    p1: [1, 0.5, 3.141592653589793];
    p2: [0, 0, 0];
end;

Sgate(0.123, 0.7853981633974483) | [2];
BSgate(p0, 0.0) | [1, 2];
Rgate(p1) | [2];
MeasureHomodyne(phi: p0) | [0];
```
Specific changes:
* A "constant" block is added to the grammar and parser.
* A `xir.Program.constant` property is added, retrieving the `xir.Program._constants` dictionary, which is populated by the parser.
* A validation check is added to make sure that constants are not being used as definition parameters.
* A bug in the float-conversion function `xir.program.get_floats` is squashed, which caused nested lists and lists in dictionaries to not be properly converted.

**Benefits:**
It's now possible to declare constants in an XIR script, which can be used to reference arrays, strings, booleans, or numbers without having to write them out several times (e.g., a clear use case is large arrays that can take time to parse, and that could make statements easier to read).

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None