### PR TITLE
Fix indentation and output declaration in Grammar tutorial

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -20,7 +20,7 @@
 ### Documentation
 
 * The `out` declaration in the Grammar overview is now valid XIR syntax.
-  [(#8)](https://github.com/XanaduAI/xir/pull/2)
+  [(#8)](https://github.com/XanaduAI/xir/pull/8)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 ### Documentation
 
+* The `out` declaration in the Grammar overview is now valid XIR syntax.
+  [(#8)](https://github.com/XanaduAI/xir/pull/2)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/docs/use/grammar.rst
+++ b/docs/use/grammar.rst
@@ -8,7 +8,7 @@ An XIR script consists of five parts, all of which are optional. Each of these
 is expanded on in detail following some initial examples:
 
 1. **Includes.** Included XIR scripts which have been prepared to contain useful
-declarations or definitions.
+   declarations or definitions.
 
 .. code-block:: text
 

--- a/docs/use/grammar.rst
+++ b/docs/use/grammar.rst
@@ -29,7 +29,7 @@ is expanded on in detail following some initial examples:
     gate CNOT [control, target];
     obs ScaledZ(scalar) [wire];
     func arctan(x);
-    out amplitude;
+    out amplitude(state) [0..2];
 
 
 4. **Definitions.** Definitions of gates and observables.


### PR DESCRIPTION
**Context:**
The [overview section of the Grammar tutorial](https://xir.readthedocs.io/en/latest/use/grammar.html#overview) has a few small issues:
1. The first item in the ordered list is not indented.
2. The XIR syntax of the `out` declaration is invalid.

![image](https://user-images.githubusercontent.com/5883774/143608955-d319efb0-120f-4d70-9db0-47096abf840d.png)


**Description of the Change:**
- The overview section of the Grammar tutorial now looks like this:

![image](https://user-images.githubusercontent.com/5883774/143609218-9689b14c-f4ac-4660-82b7-02144965c482.png)

**Benefits:**
- The Grammar tutorial is more useful and aesthetic.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.