### PR TITLE
Increment version to 0.2.0-dev (again)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,3 +1,6 @@
+## Release 0.2.0 (development release)
+
+
 ## Release 0.1.1 (current release)
 
 ### New features since last release

--- a/xir/_version.py
+++ b/xir/_version.py
@@ -1,3 +1,3 @@
 """The current version number. Uses semantic versioning (https://semver.org)"""
 
-__version__ = "0.1.1"
+__version__ = "0.2.0-dev"


### PR DESCRIPTION
This PR increments the XIR version to `0.2.0-dev` following the `0.1.1` release.