### PR TITLE
Automated version bumps with GitHub Actions workflows

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release 0.2.0 (development release)
 
+### Improvements
+
+* Version bumping is now handled by a pair of GitHub Actions workflows.
+  [(#12)](https://github.com/XanaduAI/xir/pull/12)
+
 ### Bug Fixes
 
 * The license file is included in the source distribution, even when using `setuptools <56.0.0`.
@@ -9,7 +14,7 @@
 
 This release contains contributions from (in alphabetical order):
 
-[Bastian Zimmermann](https://github.com/BastianZim)
+[Mikhail Andrenkov](https://github.com/Mandrenkov), [Bastian Zimmermann](https://github.com/BastianZim)
 
 ## Release 0.1.1 (current release)
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Improvements
 
-* Version bumping is now handled by a pair of GitHub Actions workflows.
+* A pair of GitHub Actions workflows have been added to generate pull requests
+  for pre-release and post-release version bumps, respectively.
   [(#12)](https://github.com/XanaduAI/xir/pull/12)
 
 ### Bug Fixes

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -75,7 +75,7 @@ This release contains contributions from (in alphabetical order):
 [Mikhail Andrenkov](https://github.com/Mandrenkov), [Theodor Isacsson](https://github.com/thisac).
 
 
-## Release 0.1.0 (current release)
+## Release 0.1.0
 
 ### New features since last release
 

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -12,15 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Derive XIR versions
+      - name: Derive versions
         id: versions
         run: |
           old_version=`grep -oP '(?<=__version__ = ").*(?=")' xir/_version.py`
           new_version=`echo $old_version | awk '{split($0,v,"."); print v[1] "." v[2]+1 "." v[3] "-dev"}'`
-
-          if [ -z "$old_version" ]; then
-            echo "Failed to parse XIR version from xir/_version.py." && exit 1
-          fi
 
           echo "::set-output name=old_version::$old_version"
           echo "::set-output name=new_version::$new_version"

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -1,0 +1,56 @@
+name: Post-Release Version Bump
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  post_release_version_bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Derive XIR versions
+        id: versions
+        run: |
+          old_version=`grep -oP '(?<=__version__ = ").*(?=")' xir/_version.py`
+          new_version=`echo $old_version | awk '{split($0,v,"."); print v[1] "." v[2]+1 "." v[3] "-dev"}'`
+
+          if [ -z "$old_version" ]; then
+            echo "Failed to parse XIR version from xir/_version.py." && exit 1
+          fi
+
+          echo "::set-output name=old_version::$old_version"
+          echo "::set-output name=new_version::$new_version"
+
+      - name: Bump version in _version.py
+        run:
+          sed -i 's/${{ steps.versions.outputs.old_version }}/${{ steps.versions.outputs.new_version }}/' xir/_version.py
+
+      - name: Bump version in changelog
+        run: |
+          next_release_version=${{ steps.versions.outputs.new_version }}
+          next_release_version=${next_release_version%-dev}
+
+          header="## Release ${next_release_version} (development release)
+
+          ### Contributors
+
+          This release contains contributions from (in alphabetical order):
+          "
+
+          printf '%s\n%s\n' "$header" "$(cat .github/CHANGELOG.md)" > .github/CHANGELOG.md
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: main
+          title: Post-release version bump to \`${{ steps.versions.outputs.new_version }}\`
+          body: >
+            This PR bumps the XIR version from \`${{ steps.versions.outputs.old_version }}\`
+            to \`${{ steps.versions.outputs.new_version }}\`.
+          commit-message: Bump version to \`${{ steps.versions.outputs.new_version }}\`
+          branch: post-release-version-bump
+          reviewers: mandrenkov, thisac

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -10,15 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Derive XIR versions
+      - name: Derive versions
         id: versions
         run: |
           old_version=`grep -oP '(?<=__version__ = ").*(?=")' xir/_version.py`
           new_version=${old_version%-dev}
-
-          if [ -z "$old_version" ]; then
-            echo "Failed to parse XIR version from xir/_version.py." && exit 1
-          fi
 
           echo "::set-output name=old_version::$old_version"
           echo "::set-output name=new_version::$new_version"

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -8,11 +8,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Install Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: "3.9"
-
       - uses: actions/checkout@v2
 
       - name: Derive XIR versions
@@ -36,7 +31,6 @@ jobs:
         run: |
           sed -i 's/ (current release)//' .github/CHANGELOG.md
           sed -i 's/ (development release)/ (current release)/' .github/CHANGELOG.md
-          echo "Hey there, it's \`brackets\`"
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -1,0 +1,51 @@
+name: Pre-Release Version Bump
+
+on:
+  workflow_dispatch:
+
+jobs:
+  pre_release_version_bump:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Install Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.9"
+
+      - uses: actions/checkout@v2
+
+      - name: Derive XIR versions
+        id: versions
+        run: |
+          old_version=`grep -oP '(?<=__version__ = ").*(?=")' xir/_version.py`
+          new_version=${old_version%-dev}
+
+          if [ -z "$old_version" ]; then
+            echo "Failed to parse XIR version from xir/_version.py." && exit 1
+          fi
+
+          echo "::set-output name=old_version::$old_version"
+          echo "::set-output name=new_version::$new_version"
+
+      - name: Bump version in _version.py
+        run:
+          sed -i 's/${{ steps.versions.outputs.old_version }}/${{ steps.versions.outputs.new_version }}/' xir/_version.py
+
+      - name: Bump version in changelog
+        run: |
+          sed -i 's/ (current release)//' .github/CHANGELOG.md
+          sed -i 's/ (development release)/ (current release)/' .github/CHANGELOG.md
+          echo "Hey there, it's \`brackets\`"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          base: main
+          title: Bump version to \`${{ steps.versions.outputs.new_version }}\`
+          body: >
+            This PR bumps the XIR version from \`${{ steps.versions.outputs.old_version }}\`
+            to \`${{ steps.versions.outputs.new_version }}\`.
+          commit-message: Bump version to \`${{ steps.versions.outputs.new_version }}\`
+          branch: pre-release-version-bump
+          reviewers: mandrenkov, thisac

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -36,7 +36,7 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           base: main
-          title: Bump version to \`${{ steps.versions.outputs.new_version }}\`
+          title: Pre-release version bump to \`${{ steps.versions.outputs.new_version }}\`
           body: >
             This PR bumps the XIR version from \`${{ steps.versions.outputs.old_version }}\`
             to \`${{ steps.versions.outputs.new_version }}\`.


### PR DESCRIPTION
**Context:**
To release a new version of the XIR, two PRs are required:
1. A pre-release PR to remove the `-dev` suffix from the current version.
2. A post-release PR to increment the minor version and add a `-dev` suffix.

**Description of the Change:**
* A separate GitHub Actions workflow has been added for each PR described above.
* Each of these workflows update the [changelog](.github/CHANGELOG.md) and modify the version specified in [_version.py](xir/_version.py).

**Benefits:**
* There is less friction for making new XIR releases.

**Possible Drawbacks:**
* Some releases (e.g., major version upgrades) still require a manual PR.

**Related GitHub Issues:**
None.