### PR TITLE
Fix version bump GitHub Actions workflows

### DIFF
--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -43,10 +43,10 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           base: main
-          title: Post-release version bump to \`${{ steps.versions.outputs.new_version }}\`
+          title: Post-release version bump to `${{ steps.versions.outputs.new_version }}`
           body: >
-            This PR bumps the XIR version from \`${{ steps.versions.outputs.old_version }}\`
-            to \`${{ steps.versions.outputs.new_version }}\`.
-          commit-message: Bump version to \`${{ steps.versions.outputs.new_version }}\`
+            This PR bumps the XIR version from `${{ steps.versions.outputs.old_version }}`
+            to `${{ steps.versions.outputs.new_version }}`.
+          commit-message: Bump version to `${{ steps.versions.outputs.new_version }}`
           branch: post-release-version-bump
           reviewers: mandrenkov, thisac, trbromley

--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -49,4 +49,4 @@ jobs:
             to \`${{ steps.versions.outputs.new_version }}\`.
           commit-message: Bump version to \`${{ steps.versions.outputs.new_version }}\`
           branch: post-release-version-bump
-          reviewers: mandrenkov, thisac
+          reviewers: mandrenkov, thisac, trbromley

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -38,4 +38,4 @@ jobs:
             to \`${{ steps.versions.outputs.new_version }}\`.
           commit-message: Bump version to \`${{ steps.versions.outputs.new_version }}\`
           branch: pre-release-version-bump
-          reviewers: mandrenkov, thisac
+          reviewers: mandrenkov, thisac, trbromley

--- a/.github/workflows/pre_release_version_bump.yml
+++ b/.github/workflows/pre_release_version_bump.yml
@@ -32,10 +32,10 @@ jobs:
         uses: peter-evans/create-pull-request@v3
         with:
           base: main
-          title: Pre-release version bump to \`${{ steps.versions.outputs.new_version }}\`
+          title: Pre-release version bump to `${{ steps.versions.outputs.new_version }}`
           body: >
-            This PR bumps the XIR version from \`${{ steps.versions.outputs.old_version }}\`
-            to \`${{ steps.versions.outputs.new_version }}\`.
-          commit-message: Bump version to \`${{ steps.versions.outputs.new_version }}\`
+            This PR bumps the XIR version from `${{ steps.versions.outputs.old_version }}`
+            to `${{ steps.versions.outputs.new_version }}`.
+          commit-message: Bump version to `${{ steps.versions.outputs.new_version }}`
           branch: pre-release-version-bump
           reviewers: mandrenkov, thisac, trbromley


### PR DESCRIPTION
**Context:**
Recently, #12 introduced a pair of GitHub Actions workflow to automate the version bumps performed before and after XIR releases. The goal of this PR is to fix a couple of the issues seen in #13 and #14.

**Description of the Change:**
* Added @trbromley to the list of version bump PR reviewers.
* Replaced `` \` `` with `` ` `` in the Create Pull Request steps.

**Benefits:**
* Improved formatting and more candidate reviewers.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.