### PR TITLE
Expand ranges in wire lists

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## Release 0.3.0 (development release)
 
+### Bug Fixes
+
+* Ranges are now expanded correctly in wire lists such that `[0..2]` means `[0, 1]`.
+  [(#13)](https://github.com/XanaduAI/xir/pull/13)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bug Fixes
 
 * Ranges are now expanded correctly in wire lists such that `[0..2]` means `[0, 1]`.
-  [(#13)](https://github.com/XanaduAI/xir/pull/13)
+  [(#16)](https://github.com/XanaduAI/xir/pull/16)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 This release contains contributions from (in alphabetical order):
 
+[Mikhail Andrenkov](https://github.com/Mandrenkov)
+
 ## Release 0.2.0 (current release)
 
 ### Improvements

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -312,3 +312,36 @@ class TestParser:
 
         assert program.declarations["obs"][3].name == "Orange"
         assert program.declarations["obs"][3].wires == expected_wires
+
+    @pytest.mark.parametrize(
+        "script_wires, expected_wires",
+        [
+            (
+                "[0..1]",
+                (0,),
+            ),
+            (
+                "[0..2]",
+                (0, 1),
+            ),
+            (
+                "[2..5]",
+                (2, 3, 4),
+            ),
+            (
+                "[1..3, 4..6]",
+                (1, 2, 4, 5),
+            ),
+            (
+                "[0, 3..6, 7]",
+                (0, 3, 4, 5, 7),
+            ),
+        ],
+    )
+    def test_wire_range(self, script_wires, expected_wires):
+        """Tests that ranges in wire lists are parsed correctly."""
+        script = f"gate Any {script_wires};"
+        program = parse_script(script)
+
+        assert program.declarations["gate"][0].name == "Any"
+        assert program.declarations["gate"][0].wires == expected_wires

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -1,6 +1,7 @@
 """This module contains the :class:`xir.Transformer` class and the XIR parser."""
 import math
 from decimal import Decimal
+from itertools import chain
 
 import lark
 from lark import v_args
@@ -297,8 +298,9 @@ class Transformer(lark.Transformer):
         self._program.add_declaration(decl)
 
     def wire_list(self, args):
-        """List of wires."""
-        return args
+        """Tuple of wires."""
+        nested = (arg if isinstance(arg, range) else [arg] for arg in args)
+        return tuple(chain(*nested))
 
     def ARBITRARY_NUM_WIRES(self, _):
         """Arbitrary number of wires."""


### PR DESCRIPTION
**Context:**
Using XIR version 0.2.0, the Python script
```python
import xir

prog_1 = xir.parse_script("gate CNOT [0, 1]; CNOT | [0..2];")
prog_2 = xir.parse_script("gate CNOT [0, 1]; CNOT | [0, 1];")

print(xir.Validator(prog_1).run(raise_exception=False))
print(xir.Validator(prog_2).run(raise_exception=False))
```
outputs
```
["Statement 'CNOT | [range(0, 2)]' has 1 wire(s). Expected 2."]
None
```
instead of
```
None
None
```

**Description of the Change:**
* Range arguments in wire lists are now expanded by the XIR parser.

**Benefits:**
* Ranges can (once again) be used to specify contiguous subsets of wires.

**Possible Drawbacks:**
None.

**Related GitHub Issues:**
None.