### PR TITLE
Subtraction bug in parser

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -3,7 +3,7 @@
 ### Bug Fixes
 
 * Expressions containing subtraction of variables now use the correct operation.
-  [(#16)](https://github.com/XanaduAI/xir/pull/17)
+  [(#17)](https://github.com/XanaduAI/xir/pull/17)
 
 ### Contributors
 

--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -1,8 +1,15 @@
 ## Release 0.3.0 (development release)
 
+### Bug Fixes
+
+* Expressions containing subtraction of variables now use the correct operation.
+  [(#16)](https://github.com/XanaduAI/xir/pull/17)
+
 ### Contributors
 
 This release contains contributions from (in alphabetical order):
+
+[Theodor Isacsson](https://github.com/thisac)
 
 ## Release 0.2.1 (current release)
 

--- a/xir/parser.py
+++ b/xir/parser.py
@@ -353,7 +353,7 @@ class Transformer(lark.Transformer):
         """
         if all(isinstance(a, (int, Decimal, DecimalComplex)) for a in args):
             return args[0] - args[1]
-        return "(" + " + ".join(map(str, args)) + ")"
+        return "(" + " - ".join(map(str, args)) + ")"
 
     def prod(self, args):
         """Product operation.


### PR DESCRIPTION
**Context:**
When subtracting a variable in an expression, the `+` operation is used instead of the expected `-`. This is due to a typo in the `sub` function in the parser.
```pycon
>>> import xir
>>> xir.parse_script("options:\n\top: a-b;\nend;").options
{'op': '(a + b)'}
```

**Description of the Change:**
`+` is changed to `-` in the `sub` function in the parser.

```pycon
>>> import xir
>>> xir.parse_script("options:\n\top: a-b;\nend;").options
{'op': '(a - b)'}
```

**Benefits:**
Subtracting variables work as expected.

**Possible Drawbacks:**
None

**Related GitHub Issues:**
None