### PR TITLE
Ensure XIR source distribution is installable

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Expressions containing subtraction of variables now use the correct operation.
   [(#17)](https://github.com/XanaduAI/xir/pull/17)
 
+* Running `make dist` now produces an installable source distribution.
+  [(#22)](https://github.com/XanaduAI/xir/pull/22)
+
 ### Documentation
 
 * The centralized [Xanadu Sphinx Theme](https://github.com/XanaduAI/xanadu-sphinx-theme)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-lark-parser>=0.11.0
+lark-parser==0.12.0

--- a/setup.py
+++ b/setup.py
@@ -4,8 +4,7 @@ import re
 with open("xir/_version.py") as f:
     version = f.readlines()[-1].split()[-1].strip("\"'")
 
-with open("requirements.txt", "r") as f:
-    requirements = re.sub(r"#.*", "", f.read()).split()
+requirements = ["lark-parser>=0.11.0"]
 
 info = {
     "description": "XIR is an intermediate representation (IR) for quantum circuits.",


### PR DESCRIPTION
**Context:**

The source distribution generated by `make dist` is not installable due to a missing `requirements.txt` file:
```console
$ pip install quantum-xir-0.3.0.dev0.tar.gz
Processing ./quantum-xir-0.3.0.dev0.tar.gz
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [6 lines of output]
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "/private/var/folders/73/zrjp1cp171xdx_03vr4krtdr0000gq/T/pip-req-build-fbk4lija/setup.py", line 7, in <module>
          with open("requirements.txt", "r") as f:
      FileNotFoundError: [Errno 2] No such file or directory: 'requirements.txt'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```

**Description of the Change:**

* Decoupled the requirements in `setup.py` and `requirements.txt`. As a rule of thumb, `setup.py` should specify all compatible versions of a dependency while `requirements.txt` should pin dependencies to specific versions.

**Benefits:**

* The XIR source distribution is installable:

```console
$ pip install quantum-xir-0.3.0.dev0.tar.gz
Processing ./quantum-xir-0.3.0.dev0.tar.gz
  Preparing metadata (setup.py) ... done
Collecting lark-parser>=0.11.0
  Using cached lark_parser-0.12.0-py2.py3-none-any.whl (103 kB)
Installing collected packages: lark-parser, quantum-xir
  DEPRECATION: quantum-xir is being installed using the legacy 'setup.py install' method, because it does not have a 'pyproject.toml' and the 'wheel' package is not installed. pip 23.1 will enforce this behaviour change. A possible replacement is to enable the '--use-pep517' option. Discussion can be found at https://github.com/pypa/pip/issues/8559
  Running setup.py install for quantum-xir ... done
Successfully installed lark-parser-0.12.0 quantum-xir-0.3.0.dev0
``` 

**Possible Drawbacks:**

* There is a slight risk of dependencies in `setup.py` and `requirements.txt` becoming desynchronized.

**Related GitHub Issues:**

Resolves #21.