### PR TITLE
Remove set-output command

### DIFF
--- a/.github/workflows/post_release_version_bump.yml
+++ b/.github/workflows/post_release_version_bump.yml
@@ -18,8 +18,8 @@ jobs:
           old_version=`grep -oP '(?<=__version__ = ").*(?=")' xir/_version.py`
           new_version=`echo $old_version | awk '{split($0,v,"."); print v[1] "." v[2]+1 "." v[3] "-dev"}'`
 
-          echo "::set-output name=old_version::$old_version"
-          echo "::set-output name=new_version::$new_version"
+          echo "old_version=$old_version" >> $GITHUB_OUTPUT
+          echo "new_version=$new_version" >> $GITHUB_OUTPUT
 
       - name: Bump version in _version.py
         run:


### PR DESCRIPTION
**Context:**
Github has deprecated and will be removing the `set-output` command shortly.

**Description of the Change:**
Replace `set-output` with write to output env variable. 

**Benefits:**
Actions will continue to work.

**Possible Drawbacks:**

**Related GitHub Issues:**